### PR TITLE
Add RemoteApplication and -Endpoint to description

### DIFF
--- a/model_test.go
+++ b/model_test.go
@@ -683,8 +683,8 @@ version: 1
 }
 
 func (s *ModelSerializationSuite) TestImportingWithRemoteApplicationsFails(c *gc.C) {
-	model := NewModel(ModelArgs{Owner: names.NewUserTag("veils")})
-	rapp := model.AddRemoteApplication(RemoteApplicationArgs{
+	initial := NewModel(ModelArgs{Owner: names.NewUserTag("veils")})
+	rapp := initial.AddRemoteApplication(RemoteApplicationArgs{
 		Tag:         names.NewApplicationTag("bloom"),
 		OfferName:   "toman",
 		URL:         "other.mysql",
@@ -697,11 +697,14 @@ func (s *ModelSerializationSuite) TestImportingWithRemoteApplicationsFails(c *gc
 		Interface: "mysql",
 		Scope:     "global",
 	})
-	bytes, err := Serialize(model)
+	remoteApplications := initial.RemoteApplications()
+
+	bytes, err := Serialize(initial)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = Deserialize(bytes)
-	c.Assert(err, gc.ErrorMatches, "remote-applications: importing remote applications is not supported yet")
+	result, err := Deserialize(bytes)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.RemoteApplications(), gc.DeepEquals, remoteApplications)
 }
 
 func (*ModelSerializationSuite) TestRemoteApplicationsGetter(c *gc.C) {

--- a/remoteapplication.go
+++ b/remoteapplication.go
@@ -1,0 +1,122 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package description
+
+import (
+	"github.com/juju/errors"
+	"gopkg.in/juju/names.v2"
+)
+
+// RemoteApplication represents an application in another model that
+// can participate in a relation in this model.
+type RemoteApplication interface {
+	Tag() names.ApplicationTag
+	Name() string
+	OfferName() string
+	URL() string
+	SourceModelTag() names.ModelTag
+	Registered() bool
+
+	Endpoints() []RemoteEndpoint
+	AddEndpoint(RemoteEndpointArgs) RemoteEndpoint
+}
+
+type remoteApplications struct {
+	Version            int                  `yaml:"version"`
+	RemoteApplications []*remoteApplication `yaml:"remote-applications"`
+}
+
+type remoteApplication struct {
+	Name_            string          `yaml:"name"`
+	OfferName_       string          `yaml:"offer-name"`
+	URL_             string          `yaml:"url"`
+	SourceModelUUID_ string          `yaml:"source-model-uuid"`
+	Endpoints_       remoteEndpoints `yaml:"endpoints,omitempty"`
+	Registered_      bool            `yaml:"registered,omitempty"`
+}
+
+// RemoteApplicationArgs is an argument struct used to add a remote
+// application to the Model.
+type RemoteApplicationArgs struct {
+	Tag         names.ApplicationTag
+	OfferName   string
+	URL         string
+	SourceModel names.ModelTag
+	Registered  bool
+}
+
+func newRemoteApplication(args RemoteApplicationArgs) *remoteApplication {
+	a := &remoteApplication{
+		Name_:            args.Tag.Id(),
+		OfferName_:       args.OfferName,
+		URL_:             args.URL,
+		SourceModelUUID_: args.SourceModel.Id(),
+		Registered_:      args.Registered,
+	}
+	a.setEndpoints(nil)
+	return a
+}
+
+// Tag implements RemoteApplication.
+func (a *remoteApplication) Tag() names.ApplicationTag {
+	return names.NewApplicationTag(a.Name_)
+}
+
+// Name implements RemoteApplication.
+func (a *remoteApplication) Name() string {
+	return a.Name_
+}
+
+// OfferName implements RemoteApplication.
+func (a *remoteApplication) OfferName() string {
+	return a.OfferName_
+}
+
+// URL implements RemoteApplication.
+func (a *remoteApplication) URL() string {
+	return a.URL_
+}
+
+// SourceModelTag implements RemoteApplication.
+func (a *remoteApplication) SourceModelTag() names.ModelTag {
+	return names.NewModelTag(a.SourceModelUUID_)
+}
+
+// Registered implements RemoteApplication.
+func (a *remoteApplication) Registered() bool {
+	return a.Registered_
+}
+
+// Endpoints implements RemoteApplication.
+func (a *remoteApplication) Endpoints() []RemoteEndpoint {
+	result := make([]RemoteEndpoint, len(a.Endpoints_.Endpoints))
+	for i, endpoint := range a.Endpoints_.Endpoints {
+		result[i] = endpoint
+	}
+	return result
+}
+
+// AddEndpoint implements RemoteApplication.
+func (a *remoteApplication) AddEndpoint(args RemoteEndpointArgs) RemoteEndpoint {
+	ep := newRemoteEndpoint(args)
+	a.Endpoints_.Endpoints = append(a.Endpoints_.Endpoints, ep)
+	return ep
+}
+
+func (a *remoteApplication) setEndpoints(endpointList []*remoteEndpoint) {
+	a.Endpoints_ = remoteEndpoints{
+		Version:   1,
+		Endpoints: endpointList,
+	}
+}
+
+func importRemoteApplications(sourceMap map[string]interface{}) ([]*remoteApplication, error) {
+	// TODO(babbageclunk): implement importing remote applications
+	if val, ok := sourceMap["remote-applications"]; ok {
+		if items, ok := val.([]interface{}); ok && len(items) != 0 {
+			return nil, errors.New("importing remote applications is not supported yet")
+		}
+	}
+	return nil, nil
+}

--- a/remoteapplication_test.go
+++ b/remoteapplication_test.go
@@ -1,0 +1,148 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package description
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/names.v2"
+	"gopkg.in/yaml.v2"
+)
+
+type RemoteApplicationSerializationSuite struct {
+	SliceSerializationSuite
+}
+
+var _ = gc.Suite(&RemoteApplicationSerializationSuite{})
+
+func (s *RemoteApplicationSerializationSuite) SetUpTest(c *gc.C) {
+	s.SliceSerializationSuite.SetUpTest(c)
+	s.importName = "remote applications"
+	s.sliceName = "remote-applications"
+	s.importFunc = func(m map[string]interface{}) (interface{}, error) {
+		return importRemoteApplications(m)
+	}
+	s.testFields = func(m map[string]interface{}) {
+		m["remote-applications"] = []interface{}{}
+	}
+}
+
+func minimalRemoteApplicationMap() map[interface{}]interface{} {
+	return map[interface{}]interface{}{
+		"name":              "civil-wars",
+		"offer-name":        "barton-hollow",
+		"url":               "http://a.url",
+		"source-model-uuid": "abcd-1234",
+		"registered":        true,
+		"endpoints": map[interface{}]interface{}{
+			"version": 1,
+			"endpoints": []interface{}{map[interface{}]interface{}{
+				"name":      "lana",
+				"role":      "provider",
+				"interface": "mysql",
+				"limit":     1,
+				"scope":     "global",
+			}},
+		},
+	}
+}
+
+func minimalRemoteApplication() *remoteApplication {
+	a := newRemoteApplication(RemoteApplicationArgs{
+		Tag:         names.NewApplicationTag("civil-wars"),
+		OfferName:   "barton-hollow",
+		URL:         "http://a.url",
+		SourceModel: names.NewModelTag("abcd-1234"),
+		Registered:  true,
+	})
+	a.AddEndpoint(RemoteEndpointArgs{
+		Name:      "lana",
+		Role:      "provider",
+		Interface: "mysql",
+		Limit:     1,
+		Scope:     "global",
+	})
+	return a
+}
+
+func (*RemoteApplicationSerializationSuite) TestNew(c *gc.C) {
+	r := minimalRemoteApplication()
+	c.Check(r.Tag(), gc.Equals, names.NewApplicationTag("civil-wars"))
+	c.Check(r.Name(), gc.Equals, "civil-wars")
+	c.Check(r.OfferName(), gc.Equals, "barton-hollow")
+	c.Check(r.URL(), gc.Equals, "http://a.url")
+	c.Check(r.SourceModelTag(), gc.Equals, names.NewModelTag("abcd-1234"))
+	c.Check(r.Registered(), jc.IsTrue)
+	ep := r.Endpoints()
+	c.Assert(ep, gc.HasLen, 1)
+	c.Check(ep[0].Name(), gc.Equals, "lana")
+}
+
+func (*RemoteApplicationSerializationSuite) TestBadSchema1(c *gc.C) {
+	container := map[string]interface{}{
+		"version":             1,
+		"remote-applications": []interface{}{1234},
+	}
+	_, err := importRemoteApplications(container)
+	c.Assert(err, gc.ErrorMatches, `remote applications version schema check failed: remote-applications\[0\]: expected map, got int\(1234\)`)
+}
+
+func (*RemoteApplicationSerializationSuite) TestBadSchema2(c *gc.C) {
+	m := minimalRemoteApplicationMap()
+	m["registered"] = "blah"
+	container := map[string]interface{}{
+		"version":             1,
+		"remote-applications": []interface{}{m},
+	}
+	_, err := importRemoteApplications(container)
+	c.Assert(err, gc.ErrorMatches, `remote application 0: remote application v1 schema check failed: registered: expected bool, got string\("blah"\)`)
+}
+
+func (s *RemoteApplicationSerializationSuite) TestBadEndpoints(c *gc.C) {
+	m := minimalRemoteApplicationMap()
+	m["endpoints"] = map[interface{}]interface{}{
+		"version": 1,
+		"bishop":  "otter-trouserpress",
+	}
+	container := map[string]interface{}{
+		"version":             1,
+		"remote-applications": []interface{}{m},
+	}
+	_, err := importRemoteApplications(container)
+	c.Assert(err, gc.ErrorMatches, `remote application 0: remote endpoints version schema check failed: endpoints: expected list, got nothing`)
+}
+
+func (*RemoteApplicationSerializationSuite) TestMinimalMatches(c *gc.C) {
+	bytes, err := yaml.Marshal(minimalRemoteApplication())
+	c.Assert(err, jc.ErrorIsNil)
+
+	var source map[interface{}]interface{}
+	err = yaml.Unmarshal(bytes, &source)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(source, jc.DeepEquals, minimalRemoteApplicationMap())
+}
+
+func (s *RemoteApplicationSerializationSuite) TestRoundTrip(c *gc.C) {
+	rIn := minimalRemoteApplication()
+	rOut := s.exportImport(c, rIn)
+	c.Assert(rOut, jc.DeepEquals, rIn)
+}
+
+func (s *RemoteApplicationSerializationSuite) exportImport(c *gc.C, applicationIn *remoteApplication) *remoteApplication {
+	applicationsIn := &remoteApplications{
+		Version:            1,
+		RemoteApplications: []*remoteApplication{applicationIn},
+	}
+	bytes, err := yaml.Marshal(applicationsIn)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var source map[string]interface{}
+	err = yaml.Unmarshal(bytes, &source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	applicationsOut, err := importRemoteApplications(source)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(applicationsOut, gc.HasLen, 1)
+	return applicationsOut[0]
+}

--- a/remoteendpoint.go
+++ b/remoteendpoint.go
@@ -1,0 +1,72 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package description
+
+// RemoteEndpoint represents a connection point that can be related to
+// another application.
+type RemoteEndpoint interface {
+	Name() string
+	Role() string
+	Interface() string
+	Limit() int
+	Scope() string
+}
+
+type remoteEndpoints struct {
+	Version   int               `yaml:"version"`
+	Endpoints []*remoteEndpoint `yaml:"endpoints"`
+}
+
+type remoteEndpoint struct {
+	Name_      string `yaml:"name"`
+	Role_      string `yaml:"role"`
+	Interface_ string `yaml:"interface"`
+	Limit_     int    `yaml:"limit"`
+	Scope_     string `yaml:"scope"`
+}
+
+// RemoteEndpointArgs is an argument struct used to add a remote
+// endpoint to a remote application.
+type RemoteEndpointArgs struct {
+	Name      string
+	Role      string
+	Interface string
+	Limit     int
+	Scope     string
+}
+
+func newRemoteEndpoint(args RemoteEndpointArgs) *remoteEndpoint {
+	return &remoteEndpoint{
+		Name_:      args.Name,
+		Role_:      args.Role,
+		Interface_: args.Interface,
+		Limit_:     args.Limit,
+		Scope_:     args.Scope,
+	}
+}
+
+// Name implements RemoteEndpoint.
+func (e *remoteEndpoint) Name() string {
+	return e.Name_
+}
+
+// Role implements RemoteEndpoint.
+func (e *remoteEndpoint) Role() string {
+	return e.Role_
+}
+
+// Interface implements RemoteEndpoint.
+func (e *remoteEndpoint) Interface() string {
+	return e.Interface_
+}
+
+// Limit implements RemoteEndpoint.
+func (e *remoteEndpoint) Limit() int {
+	return e.Limit_
+}
+
+// Scope implements RemoteEndpoint.
+func (e *remoteEndpoint) Scope() string {
+	return e.Scope_
+}

--- a/remoteendpoint.go
+++ b/remoteendpoint.go
@@ -3,6 +3,11 @@
 
 package description
 
+import (
+	"github.com/juju/errors"
+	"github.com/juju/schema"
+)
+
 // RemoteEndpoint represents a connection point that can be related to
 // another application.
 type RemoteEndpoint interface {
@@ -69,4 +74,75 @@ func (e *remoteEndpoint) Limit() int {
 // Scope implements RemoteEndpoint.
 func (e *remoteEndpoint) Scope() string {
 	return e.Scope_
+}
+
+func importRemoteEndpoints(sourceMap map[string]interface{}) ([]*remoteEndpoint, error) {
+	checker := versionedChecker("endpoints")
+	coerced, err := checker.Coerce(sourceMap, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "remote endpoints version schema check failed")
+	}
+	valid := coerced.(map[string]interface{})
+
+	version := int(valid["version"].(int64))
+	importFunc, ok := remoteEndpointDeserializationFuncs[version]
+	if !ok {
+		return nil, errors.NotValidf("version %d", version)
+	}
+	sourceList := valid["endpoints"].([]interface{})
+	return importRemoteEndpointList(sourceList, importFunc)
+}
+
+func importRemoteEndpointList(sourceList []interface{}, importFunc remoteEndpointDeserializationFunc) ([]*remoteEndpoint, error) {
+	result := make([]*remoteEndpoint, 0, len(sourceList))
+	for i, value := range sourceList {
+		source, ok := value.(map[string]interface{})
+		if !ok {
+			return nil, errors.Errorf("unexpected value for remote endpoint %d, %T", i, value)
+		}
+		device, err := importFunc(source)
+		if err != nil {
+			return nil, errors.Annotatef(err, "remote endpoint %d", i)
+		}
+		result = append(result, device)
+	}
+	return result, nil
+}
+
+type remoteEndpointDeserializationFunc func(map[string]interface{}) (*remoteEndpoint, error)
+
+var remoteEndpointDeserializationFuncs = map[int]remoteEndpointDeserializationFunc{
+	1: importRemoteEndpointV1,
+}
+
+func importRemoteEndpointV1(source map[string]interface{}) (*remoteEndpoint, error) {
+	fields := schema.Fields{
+		"name":      schema.String(),
+		"role":      schema.String(),
+		"interface": schema.String(),
+		"limit":     schema.Int(),
+		"scope":     schema.String(),
+	}
+
+	defaults := schema.Defaults{
+		"limit": 0,
+	}
+	checker := schema.FieldMap(fields, defaults)
+
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "remote endpoint v1 schema check failed")
+	}
+	valid := coerced.(map[string]interface{})
+	// From here we know that the map returned from the schema coercion
+	// contains fields of the right type.
+	result := &remoteEndpoint{
+		Name_:      valid["name"].(string),
+		Role_:      valid["role"].(string),
+		Interface_: valid["interface"].(string),
+		Limit_:     int(valid["limit"].(int64)),
+		Scope_:     valid["scope"].(string),
+	}
+
+	return result, nil
 }

--- a/remoteendpoint_test.go
+++ b/remoteendpoint_test.go
@@ -1,0 +1,111 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package description
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
+)
+
+type RemoteEndpointSerializationSuite struct {
+	SliceSerializationSuite
+}
+
+var _ = gc.Suite(&RemoteEndpointSerializationSuite{})
+
+func (s *RemoteEndpointSerializationSuite) SetUpTest(c *gc.C) {
+	s.SliceSerializationSuite.SetUpTest(c)
+	s.importName = "remote endpoints"
+	s.sliceName = "endpoints"
+	s.importFunc = func(m map[string]interface{}) (interface{}, error) {
+		return importRemoteEndpoints(m)
+	}
+	s.testFields = func(m map[string]interface{}) {
+		m["endpoints"] = []interface{}{}
+	}
+}
+
+func minimalRemoteEndpointMap() map[interface{}]interface{} {
+	return map[interface{}]interface{}{
+		"name":      "lana",
+		"role":      "provider",
+		"interface": "mysql",
+		"limit":     1,
+		"scope":     "global",
+	}
+}
+
+func minimalRemoteEndpoint() *remoteEndpoint {
+	return newRemoteEndpoint(RemoteEndpointArgs{
+		Name:      "lana",
+		Role:      "provider",
+		Interface: "mysql",
+		Limit:     1,
+		Scope:     "global",
+	})
+}
+
+func (*RemoteEndpointSerializationSuite) TestNew(c *gc.C) {
+	r := minimalRemoteEndpoint()
+	c.Check(r.Name(), gc.Equals, "lana")
+	c.Check(r.Role(), gc.Equals, "provider")
+	c.Check(r.Interface(), gc.Equals, "mysql")
+	c.Check(r.Limit(), gc.Equals, 1)
+	c.Check(r.Scope(), gc.Equals, "global")
+}
+
+func (*RemoteEndpointSerializationSuite) TestBadSchema1(c *gc.C) {
+	container := map[string]interface{}{
+		"version":   1,
+		"endpoints": []interface{}{1234},
+	}
+	_, err := importRemoteEndpoints(container)
+	c.Assert(err, gc.ErrorMatches, `remote endpoints version schema check failed: endpoints\[0\]: expected map, got int\(1234\)`)
+}
+
+func (*RemoteEndpointSerializationSuite) TestBadSchema2(c *gc.C) {
+	m := minimalRemoteEndpointMap()
+	m["limit"] = "blah"
+	container := map[string]interface{}{
+		"version":   1,
+		"endpoints": []interface{}{m},
+	}
+	_, err := importRemoteEndpoints(container)
+	c.Assert(err, gc.ErrorMatches, `remote endpoint 0: remote endpoint v1 schema check failed: limit: expected int, got string\("blah"\)`)
+}
+
+func (*RemoteEndpointSerializationSuite) TestMinimalMatches(c *gc.C) {
+	bytes, err := yaml.Marshal(minimalRemoteEndpoint())
+	c.Assert(err, jc.ErrorIsNil)
+
+	var source map[interface{}]interface{}
+	err = yaml.Unmarshal(bytes, &source)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(source, jc.DeepEquals, minimalRemoteEndpointMap())
+}
+
+func (s *RemoteEndpointSerializationSuite) TestRoundTrip(c *gc.C) {
+	rIn := minimalRemoteEndpoint()
+	rOut := s.exportImport(c, rIn)
+	c.Assert(rOut, jc.DeepEquals, rIn)
+}
+
+func (s *RemoteEndpointSerializationSuite) exportImport(c *gc.C, endpointIn *remoteEndpoint) *remoteEndpoint {
+	endpointsIn := &remoteEndpoints{
+		Version:   1,
+		Endpoints: []*remoteEndpoint{endpointIn},
+	}
+	bytes, err := yaml.Marshal(endpointsIn)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var source map[string]interface{}
+	err = yaml.Unmarshal(bytes, &source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	endpointsOut, err := importRemoteEndpoints(source)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(endpointsOut, gc.HasLen, 1)
+	return endpointsOut[0]
+}


### PR DESCRIPTION
This will allow dump-model to work on models with cross-model relations.

For now remote applications will be serializable but not importable. We 
don't want to accidentally allow a migration to appear to succeed while 
not migrating remote applications from the source model, and migrating 
remote applications will require much more thought.

Handle remote applications in model.Validate. Since there are no units
in the local model for a remote application, we can't check that the
settings for the endpoints and units match up.