### PR TITLE
Make storage "owner" and "attachments" optional

### DIFF
--- a/model.go
+++ b/model.go
@@ -642,7 +642,7 @@ func (m *model) AddStorage(args StorageArgs) Storage {
 
 func (m *model) setStorages(storageList []*storage) {
 	m.Storages_ = storages{
-		Version:   1,
+		Version:   2,
 		Storages_: storageList,
 	}
 }


### PR DESCRIPTION
Bump the schema version of storages to 2, and
make the owner and attachments fields of storage
optional. This is to support persistent storage
changes.