### PR TITLE
Drop "binding" from volume and filesystem

### DIFF
--- a/filesystem.go
+++ b/filesystem.go
@@ -18,7 +18,6 @@ type filesystem struct {
 	ID_        string `yaml:"id"`
 	StorageID_ string `yaml:"storage-id,omitempty"`
 	VolumeID_  string `yaml:"volume-id,omitempty"`
-	Binding_   string `yaml:"binding,omitempty"`
 
 	Provisioned_  bool   `yaml:"provisioned"`
 	Size_         uint64 `yaml:"size"`
@@ -48,7 +47,6 @@ type FilesystemArgs struct {
 	Tag          names.FilesystemTag
 	Storage      names.StorageTag
 	Volume       names.VolumeTag
-	Binding      names.Tag
 	Provisioned  bool
 	Size         uint64
 	Pool         string
@@ -65,9 +63,6 @@ func newFilesystem(args FilesystemArgs) *filesystem {
 		Pool_:          args.Pool,
 		FilesystemID_:  args.FilesystemID,
 		StatusHistory_: newStatusHistory(),
-	}
-	if args.Binding != nil {
-		f.Binding_ = args.Binding.String()
 	}
 	f.setAttachments(nil)
 	return f
@@ -92,18 +87,6 @@ func (f *filesystem) Storage() names.StorageTag {
 		return names.StorageTag{}
 	}
 	return names.NewStorageTag(f.StorageID_)
-}
-
-// Binding implements Filesystem.
-func (f *filesystem) Binding() (names.Tag, error) {
-	if f.Binding_ == "" {
-		return nil, nil
-	}
-	tag, err := names.ParseTag(f.Binding_)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return tag, nil
 }
 
 // Provisioned implements Filesystem.
@@ -174,9 +157,6 @@ func (f *filesystem) Validate() error {
 	if f.Status_ == nil {
 		return errors.NotValidf("filesystem %q missing status", f.ID_)
 	}
-	if _, err := f.Binding(); err != nil {
-		return errors.Wrap(err, errors.NotValidf("filesystem %q binding", f.ID_))
-	}
 	return nil
 }
 
@@ -224,7 +204,6 @@ func importFilesystemV1(source map[string]interface{}) (*filesystem, error) {
 		"id":            schema.String(),
 		"storage-id":    schema.String(),
 		"volume-id":     schema.String(),
-		"binding":       schema.String(),
 		"provisioned":   schema.Bool(),
 		"size":          schema.ForceUint(),
 		"pool":          schema.String(),
@@ -236,7 +215,6 @@ func importFilesystemV1(source map[string]interface{}) (*filesystem, error) {
 	defaults := schema.Defaults{
 		"storage-id":    "",
 		"volume-id":     "",
-		"binding":       "",
 		"pool":          "",
 		"filesystem-id": "",
 		"attachments":   schema.Omit,
@@ -255,7 +233,6 @@ func importFilesystemV1(source map[string]interface{}) (*filesystem, error) {
 		ID_:            valid["id"].(string),
 		StorageID_:     valid["storage-id"].(string),
 		VolumeID_:      valid["volume-id"].(string),
-		Binding_:       valid["binding"].(string),
 		Provisioned_:   valid["provisioned"].(bool),
 		Size_:          valid["size"].(uint64),
 		Pool_:          valid["pool"].(string),

--- a/filesystem_test.go
+++ b/filesystem_test.go
@@ -41,7 +41,6 @@ func testFilesystemMap() map[interface{}]interface{} {
 		"id":             "1234",
 		"storage-id":     "test/1",
 		"volume-id":      "4321",
-		"binding":        "machine-42",
 		"provisioned":    true,
 		"size":           int(20 * gig),
 		"pool":           "swimming",
@@ -66,7 +65,6 @@ func testFilesystemArgs() FilesystemArgs {
 		Tag:          names.NewFilesystemTag("1234"),
 		Storage:      names.NewStorageTag("test/1"),
 		Volume:       names.NewVolumeTag("4321"),
-		Binding:      names.NewMachineTag("42"),
 		Provisioned:  true,
 		Size:         20 * gig,
 		Pool:         "swimming",
@@ -80,9 +78,6 @@ func (s *FilesystemSerializationSuite) TestNewFilesystem(c *gc.C) {
 	c.Check(filesystem.Tag(), gc.Equals, names.NewFilesystemTag("1234"))
 	c.Check(filesystem.Storage(), gc.Equals, names.NewStorageTag("test/1"))
 	c.Check(filesystem.Volume(), gc.Equals, names.NewVolumeTag("4321"))
-	binding, err := filesystem.Binding()
-	c.Check(err, jc.ErrorIsNil)
-	c.Check(binding, gc.Equals, names.NewMachineTag("42"))
 	c.Check(filesystem.Provisioned(), jc.IsTrue)
 	c.Check(filesystem.Size(), gc.Equals, 20*gig)
 	c.Check(filesystem.Pool(), gc.Equals, "swimming")

--- a/interfaces.go
+++ b/interfaces.go
@@ -337,8 +337,6 @@ type Volume interface {
 	Tag() names.VolumeTag
 	Storage() names.StorageTag
 
-	Binding() (names.Tag, error)
-
 	Provisioned() bool
 
 	Size() uint64
@@ -370,7 +368,6 @@ type Filesystem interface {
 	Tag() names.FilesystemTag
 	Volume() names.VolumeTag
 	Storage() names.StorageTag
-	Binding() (names.Tag, error)
 
 	Provisioned() bool
 

--- a/volume_test.go
+++ b/volume_test.go
@@ -40,7 +40,6 @@ func testVolumeMap() map[interface{}]interface{} {
 	return map[interface{}]interface{}{
 		"id":             "1234",
 		"storage-id":     "test/1",
-		"binding":        "machine-42",
 		"provisioned":    true,
 		"size":           int(20 * gig),
 		"pool":           "swimming",
@@ -66,7 +65,6 @@ func testVolumeArgs() VolumeArgs {
 	return VolumeArgs{
 		Tag:         names.NewVolumeTag("1234"),
 		Storage:     names.NewStorageTag("test/1"),
-		Binding:     names.NewMachineTag("42"),
 		Provisioned: true,
 		Size:        20 * gig,
 		Pool:        "swimming",
@@ -81,9 +79,6 @@ func (s *VolumeSerializationSuite) TestNewVolume(c *gc.C) {
 
 	c.Check(volume.Tag(), gc.Equals, names.NewVolumeTag("1234"))
 	c.Check(volume.Storage(), gc.Equals, names.NewStorageTag("test/1"))
-	binding, err := volume.Binding()
-	c.Check(err, jc.ErrorIsNil)
-	c.Check(binding, gc.Equals, names.NewMachineTag("42"))
 	c.Check(volume.Provisioned(), jc.IsTrue)
 	c.Check(volume.Size(), gc.Equals, 20*gig)
 	c.Check(volume.Pool(), gc.Equals, "swimming")


### PR DESCRIPTION
Does not require a version bump, as binding
was optional to begin with.