### PR TITLE
rename remote application 'registered' to 'is-consumer-proxy'

### DIFF
--- a/model_test.go
+++ b/model_test.go
@@ -596,11 +596,11 @@ func (s *ModelSerializationSuite) TestNewModelSetsRemoteApplications(c *gc.C) {
 func (s *ModelSerializationSuite) TestModelValidationHandlesRemoteApplications(c *gc.C) {
 	model := NewModel(ModelArgs{Owner: names.NewUserTag("ink-spots")})
 	remoteApp := model.AddRemoteApplication(RemoteApplicationArgs{
-		Tag:         names.NewApplicationTag("mysql"),
-		OfferName:   "mysql",
-		URL:         "other.mysql",
-		SourceModel: names.NewModelTag("some-model"),
-		Registered:  true,
+		Tag:             names.NewApplicationTag("mysql"),
+		OfferName:       "mysql",
+		URL:             "other.mysql",
+		SourceModel:     names.NewModelTag("some-model"),
+		IsConsumerProxy: true,
 	})
 	remoteApp.AddEndpoint(RemoteEndpointArgs{
 		Name:      "db",
@@ -646,11 +646,11 @@ func asStringMap(c *gc.C, model Model) map[string]interface{} {
 func (s *ModelSerializationSuite) TestSerializesRemoteApplications(c *gc.C) {
 	model := NewModel(ModelArgs{Owner: names.NewUserTag("veils")})
 	rapp := model.AddRemoteApplication(RemoteApplicationArgs{
-		Tag:         names.NewApplicationTag("bloom"),
-		OfferName:   "toman",
-		URL:         "other.mysql",
-		SourceModel: names.NewModelTag("some-model"),
-		Registered:  true,
+		Tag:             names.NewApplicationTag("bloom"),
+		OfferName:       "toman",
+		URL:             "other.mysql",
+		SourceModel:     names.NewModelTag("some-model"),
+		IsConsumerProxy: true,
 	})
 	rapp.AddEndpoint(RemoteEndpointArgs{
 		Name:      "db",
@@ -676,9 +676,9 @@ remote-applications:
       role: provider
       scope: global
     version: 1
+  is-consumer-proxy: true
   name: bloom
   offer-name: toman
-  registered: true
   source-model-uuid: some-model
   url: other.mysql
 version: 1
@@ -689,11 +689,11 @@ version: 1
 func (s *ModelSerializationSuite) TestImportingWithRemoteApplicationsFails(c *gc.C) {
 	initial := NewModel(ModelArgs{Owner: names.NewUserTag("veils")})
 	rapp := initial.AddRemoteApplication(RemoteApplicationArgs{
-		Tag:         names.NewApplicationTag("bloom"),
-		OfferName:   "toman",
-		URL:         "other.mysql",
-		SourceModel: names.NewModelTag("some-model"),
-		Registered:  true,
+		Tag:             names.NewApplicationTag("bloom"),
+		OfferName:       "toman",
+		URL:             "other.mysql",
+		SourceModel:     names.NewModelTag("some-model"),
+		IsConsumerProxy: true,
 	})
 	rapp.AddEndpoint(RemoteEndpointArgs{
 		Name:      "db",
@@ -714,11 +714,11 @@ func (s *ModelSerializationSuite) TestImportingWithRemoteApplicationsFails(c *gc
 func (*ModelSerializationSuite) TestRemoteApplicationsGetter(c *gc.C) {
 	model := NewModel(ModelArgs{Owner: names.NewUserTag("veils")})
 	model.AddRemoteApplication(RemoteApplicationArgs{
-		Tag:         names.NewApplicationTag("bloom"),
-		OfferName:   "toman",
-		URL:         "other.mysql",
-		SourceModel: names.NewModelTag("some-model"),
-		Registered:  true,
+		Tag:             names.NewApplicationTag("bloom"),
+		OfferName:       "toman",
+		URL:             "other.mysql",
+		SourceModel:     names.NewModelTag("some-model"),
+		IsConsumerProxy: true,
 	})
 	result := model.RemoteApplications()
 	c.Assert(result, gc.HasLen, 1)
@@ -750,11 +750,11 @@ func (*ModelSerializationSuite) TestVersion1Works(c *gc.C) {
 func (*ModelSerializationSuite) TestVersion1IgnoresRemoteApplications(c *gc.C) {
 	initial := NewModel(ModelArgs{Owner: names.NewUserTag("ben-harper")})
 	initial.AddRemoteApplication(RemoteApplicationArgs{
-		Tag:         names.NewApplicationTag("bloom"),
-		OfferName:   "toman",
-		URL:         "other.mysql",
-		SourceModel: names.NewModelTag("some-model"),
-		Registered:  true,
+		Tag:             names.NewApplicationTag("bloom"),
+		OfferName:       "toman",
+		URL:             "other.mysql",
+		SourceModel:     names.NewModelTag("some-model"),
+		IsConsumerProxy: true,
 	})
 	data := asStringMap(c, initial)
 	data["version"] = 1

--- a/remoteapplication.go
+++ b/remoteapplication.go
@@ -17,7 +17,7 @@ type RemoteApplication interface {
 	OfferName() string
 	URL() string
 	SourceModelTag() names.ModelTag
-	Registered() bool
+	IsConsumerProxy() bool
 
 	Endpoints() []RemoteEndpoint
 	AddEndpoint(RemoteEndpointArgs) RemoteEndpoint
@@ -34,17 +34,17 @@ type remoteApplication struct {
 	URL_             string          `yaml:"url"`
 	SourceModelUUID_ string          `yaml:"source-model-uuid"`
 	Endpoints_       remoteEndpoints `yaml:"endpoints,omitempty"`
-	Registered_      bool            `yaml:"registered,omitempty"`
+	IsConsumerProxy_ bool            `yaml:"is-consumer-proxy,omitempty"`
 }
 
 // RemoteApplicationArgs is an argument struct used to add a remote
 // application to the Model.
 type RemoteApplicationArgs struct {
-	Tag         names.ApplicationTag
-	OfferName   string
-	URL         string
-	SourceModel names.ModelTag
-	Registered  bool
+	Tag             names.ApplicationTag
+	OfferName       string
+	URL             string
+	SourceModel     names.ModelTag
+	IsConsumerProxy bool
 }
 
 func newRemoteApplication(args RemoteApplicationArgs) *remoteApplication {
@@ -53,7 +53,7 @@ func newRemoteApplication(args RemoteApplicationArgs) *remoteApplication {
 		OfferName_:       args.OfferName,
 		URL_:             args.URL,
 		SourceModelUUID_: args.SourceModel.Id(),
-		Registered_:      args.Registered,
+		IsConsumerProxy_: args.IsConsumerProxy,
 	}
 	a.setEndpoints(nil)
 	return a
@@ -84,9 +84,9 @@ func (a *remoteApplication) SourceModelTag() names.ModelTag {
 	return names.NewModelTag(a.SourceModelUUID_)
 }
 
-// Registered implements RemoteApplication.
-func (a *remoteApplication) Registered() bool {
-	return a.Registered_
+// IsConsumerProxy implements RemoteApplication.
+func (a *remoteApplication) IsConsumerProxy() bool {
+	return a.IsConsumerProxy_
 }
 
 // Endpoints implements RemoteApplication.
@@ -158,12 +158,12 @@ func importRemoteApplicationV1(source map[string]interface{}) (*remoteApplicatio
 		"url":               schema.String(),
 		"source-model-uuid": schema.String(),
 		"endpoints":         schema.StringMap(schema.Any()),
-		"registered":        schema.Bool(),
+		"is-consumer-proxy": schema.Bool(),
 	}
 
 	defaults := schema.Defaults{
-		"endpoints":  schema.Omit,
-		"registered": false,
+		"endpoints":         schema.Omit,
+		"is-consumer-proxy": false,
 	}
 	checker := schema.FieldMap(fields, defaults)
 
@@ -179,7 +179,7 @@ func importRemoteApplicationV1(source map[string]interface{}) (*remoteApplicatio
 		OfferName_:       valid["offer-name"].(string),
 		URL_:             valid["url"].(string),
 		SourceModelUUID_: valid["source-model-uuid"].(string),
-		Registered_:      valid["registered"].(bool),
+		IsConsumerProxy_: valid["is-consumer-proxy"].(bool),
 	}
 
 	if rawEndpoints, ok := valid["endpoints"]; ok {

--- a/remoteapplication_test.go
+++ b/remoteapplication_test.go
@@ -34,7 +34,7 @@ func minimalRemoteApplicationMap() map[interface{}]interface{} {
 		"offer-name":        "barton-hollow",
 		"url":               "http://a.url",
 		"source-model-uuid": "abcd-1234",
-		"registered":        true,
+		"is-consumer-proxy": true,
 		"endpoints": map[interface{}]interface{}{
 			"version": 1,
 			"endpoints": []interface{}{map[interface{}]interface{}{
@@ -50,11 +50,11 @@ func minimalRemoteApplicationMap() map[interface{}]interface{} {
 
 func minimalRemoteApplication() *remoteApplication {
 	a := newRemoteApplication(RemoteApplicationArgs{
-		Tag:         names.NewApplicationTag("civil-wars"),
-		OfferName:   "barton-hollow",
-		URL:         "http://a.url",
-		SourceModel: names.NewModelTag("abcd-1234"),
-		Registered:  true,
+		Tag:             names.NewApplicationTag("civil-wars"),
+		OfferName:       "barton-hollow",
+		URL:             "http://a.url",
+		SourceModel:     names.NewModelTag("abcd-1234"),
+		IsConsumerProxy: true,
 	})
 	a.AddEndpoint(RemoteEndpointArgs{
 		Name:      "lana",
@@ -73,7 +73,7 @@ func (*RemoteApplicationSerializationSuite) TestNew(c *gc.C) {
 	c.Check(r.OfferName(), gc.Equals, "barton-hollow")
 	c.Check(r.URL(), gc.Equals, "http://a.url")
 	c.Check(r.SourceModelTag(), gc.Equals, names.NewModelTag("abcd-1234"))
-	c.Check(r.Registered(), jc.IsTrue)
+	c.Check(r.IsConsumerProxy(), jc.IsTrue)
 	ep := r.Endpoints()
 	c.Assert(ep, gc.HasLen, 1)
 	c.Check(ep[0].Name(), gc.Equals, "lana")
@@ -90,13 +90,13 @@ func (*RemoteApplicationSerializationSuite) TestBadSchema1(c *gc.C) {
 
 func (*RemoteApplicationSerializationSuite) TestBadSchema2(c *gc.C) {
 	m := minimalRemoteApplicationMap()
-	m["registered"] = "blah"
+	m["is-consumer-proxy"] = "blah"
 	container := map[string]interface{}{
 		"version":             1,
 		"remote-applications": []interface{}{m},
 	}
 	_, err := importRemoteApplications(container)
-	c.Assert(err, gc.ErrorMatches, `remote application 0: remote application v1 schema check failed: registered: expected bool, got string\("blah"\)`)
+	c.Assert(err, gc.ErrorMatches, `remote application 0: remote application v1 schema check failed: is-consumer-proxy: expected bool, got string\("blah"\)`)
 }
 
 func (s *RemoteApplicationSerializationSuite) TestBadEndpoints(c *gc.C) {


### PR DESCRIPTION
The remote relation entity has a field that is true if it is created as a result of consuming an offer.
The field is renamed from "Registered" to "IsConsumerProxy" for clarity.
