### PR TITLE
sla, meter-status: Added sla and meter status to model description

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -424,11 +424,3 @@ type StorageConstraint interface {
 	// Count is the required number of storage instances.
 	Count() uint64
 }
-
-// SLA represents the sla for the model.
-type SLA interface {
-	// Level returns the level of the sla.
-	Level() string
-	// Level returns the credentials of the sla.
-	Credentials() []byte
-}

--- a/interfaces.go
+++ b/interfaces.go
@@ -424,3 +424,11 @@ type StorageConstraint interface {
 	// Count is the required number of storage instances.
 	Count() uint64
 }
+
+// SLA represents the sla for the model.
+type SLA interface {
+	// Level returns the level of the sla.
+	Level() string
+	// Level returns the credentials of the sla.
+	Credentials() []byte
+}

--- a/meter-status.go
+++ b/meter-status.go
@@ -1,0 +1,27 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package description
+
+// MeterStatus represents the meter status of the model.
+type MeterStatus interface {
+	// Code returns the traffic light colour code of meter status.
+	Code() string
+	// Info returns extra information corresponding to the traffic light colour.
+	Info() string
+}
+
+type meterStatus struct {
+	Code_ string `yaml:"code"`
+	Info_ string `yaml:"info"`
+}
+
+// Code returns the traffic light colour code of meter status.
+func (m meterStatus) Code() string {
+	return m.Code_
+}
+
+// Info returns extra information corresponding to the traffic light colour.
+func (m meterStatus) Info() string {
+	return m.Info_
+}

--- a/model.go
+++ b/model.go
@@ -89,6 +89,9 @@ type Model interface {
 	AddRemoteApplication(RemoteApplicationArgs) RemoteApplication
 
 	Validate() error
+
+	SetSLA(level string, credentials []byte)
+	SLA() SLA
 }
 
 // ModelArgs represent the bare minimum information that is needed
@@ -223,6 +226,8 @@ type model struct {
 	StoragePools_ storagepools `yaml:"storage-pools"`
 
 	RemoteApplications_ remoteApplications `yaml:"remote-applications"`
+
+	SLA_ sla `yaml:"sla"`
 }
 
 func (m *model) Tag() names.ModelTag {
@@ -279,6 +284,11 @@ func (m *model) Users() []User {
 	}
 	sort.Sort(ByName(result))
 	return result
+}
+
+// SLA implements Model.
+func (m *model) SLA() SLA {
+	return m.SLA_
 }
 
 // AddUser implements Model.
@@ -576,6 +586,13 @@ func (m *model) CloudCredential() CloudCredential {
 // SetCloudCredential implements Model.
 func (m *model) SetCloudCredential(args CloudCredentialArgs) {
 	m.CloudCredential_ = newCloudCredential(args)
+}
+
+func (m *model) SetSLA(level string, creds []byte) {
+	m.SLA_ = sla{
+		Level_:       level,
+		Credentials_: creds,
+	}
 }
 
 // Volumes implements Model.

--- a/model_test.go
+++ b/model_test.go
@@ -724,6 +724,58 @@ func (*ModelSerializationSuite) TestRemoteApplicationsGetter(c *gc.C) {
 	c.Assert(result, gc.HasLen, 1)
 }
 
+func (*ModelSerializationSuite) TestSetAndGetSLA(c *gc.C) {
+	model := NewModel(ModelArgs{Owner: names.NewUserTag("owner")})
+	sla := model.SetSLA("essential", "creds")
+	c.Assert(sla.Level(), gc.Equals, "essential")
+	c.Assert(sla.Credentials(), gc.Equals, "creds")
+
+	getSla := model.SLA()
+	c.Assert(getSla.Level(), gc.Equals, sla.Level())
+	c.Assert(getSla.Credentials(), jc.DeepEquals, sla.Credentials())
+}
+
+func (s *ModelSerializationSuite) TestSLA(c *gc.C) {
+	initial := NewModel(ModelArgs{Owner: names.NewUserTag("owner")})
+	sla := initial.SetSLA("essential", "creds")
+	c.Assert(sla.Level(), gc.Equals, "essential")
+	c.Assert(sla.Credentials(), gc.Equals, "creds")
+
+	bytes, err := yaml.Marshal(initial)
+	c.Assert(err, jc.ErrorIsNil)
+
+	model, err := Deserialize(bytes)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(model.SLA().Level(), gc.Equals, "essential")
+	c.Assert(model.SLA().Credentials(), gc.Equals, "creds")
+}
+
+func (*ModelSerializationSuite) TestGetAndSetMeterStatus(c *gc.C) {
+	model := NewModel(ModelArgs{Owner: names.NewUserTag("veils")})
+	ms := model.SetMeterStatus("RED", "info message")
+	c.Assert(ms.Code(), gc.Equals, "RED")
+	c.Assert(ms.Info(), gc.Equals, "info message")
+
+	getms := model.MeterStatus()
+	c.Assert(getms.Code(), gc.Equals, ms.Code())
+	c.Assert(getms.Info(), gc.Equals, ms.Info())
+}
+
+func (s *ModelSerializationSuite) TestMeterStatus(c *gc.C) {
+	initial := NewModel(ModelArgs{Owner: names.NewUserTag("owner")})
+	ms := initial.SetMeterStatus("RED", "info message")
+	c.Assert(ms.Code(), gc.Equals, "RED")
+	c.Assert(ms.Info(), gc.Equals, "info message")
+
+	bytes, err := yaml.Marshal(initial)
+	c.Assert(err, jc.ErrorIsNil)
+
+	model, err := Deserialize(bytes)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(model.MeterStatus().Code(), gc.Equals, "RED")
+	c.Assert(model.MeterStatus().Info(), gc.Equals, "info message")
+}
+
 func (*ModelSerializationSuite) TestSerializesToVersion2(c *gc.C) {
 	initial := NewModel(ModelArgs{Owner: names.NewUserTag("ben-harper")})
 	data := asStringMap(c, initial)

--- a/sla.go
+++ b/sla.go
@@ -1,11 +1,19 @@
-// Copyright 2016 Canonical Ltd.
+// Copyright 2017 Canonical Ltd.
 // Licensed under the LGPLv3, see LICENCE file for details.
 
 package description
 
+// SLA represents the sla for the model.
+type SLA interface {
+	// Level returns the level of the sla.
+	Level() string
+	// Credentials returns the credentials of the sla.
+	Credentials() string
+}
+
 type sla struct {
 	Level_       string `yaml:"level"`
-	Credentials_ []byte `yaml:"credentials"`
+	Credentials_ string `yaml:"credentials"`
 }
 
 // Level returns the level of the sla.
@@ -13,7 +21,7 @@ func (s sla) Level() string {
 	return s.Level_
 }
 
-// Level returns the Credentials of the sla.
-func (s sla) Credentials() []byte {
+// Credentials returns the Credentials of the sla.
+func (s sla) Credentials() string {
 	return s.Credentials_
 }

--- a/sla.go
+++ b/sla.go
@@ -1,0 +1,19 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package description
+
+type sla struct {
+	Level_       string `yaml:"level"`
+	Credentials_ []byte `yaml:"credentials"`
+}
+
+// Level returns the level of the sla.
+func (s sla) Level() string {
+	return s.Level_
+}
+
+// Level returns the Credentials of the sla.
+func (s sla) Credentials() []byte {
+	return s.Credentials_
+}


### PR DESCRIPTION
This pr adds SLAs and MeterStatus to the model description. This supports the ability to perform model migrations on models with an SLA and meter status