### PR TITLE
Add constraints to Storage

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -206,6 +206,10 @@ type Storage interface {
 
 	Attachments() []names.UnitTag
 
+	// Constraints returns the storage instance constraints, and a boolean
+	// reporting whether there are any.
+	Constraints() (StorageInstanceConstraints, bool)
+
 	Validate() error
 }
 
@@ -216,7 +220,7 @@ type StoragePool interface {
 	Attributes() map[string]interface{}
 }
 
-// StorageConstraint repressents the user-specified constraints for
+// StorageConstraint represents the user-specified constraints for
 // provisioning storage instances for an application unit.
 type StorageConstraint interface {
 	// Pool is the name of the storage pool from which to provision the
@@ -226,4 +230,11 @@ type StorageConstraint interface {
 	Size() uint64
 	// Count is the required number of storage instances.
 	Count() uint64
+}
+
+// StorageInstanceConstraints represents the user-specified constraints
+// for provisioning a single storage instance for an application unit.
+type StorageInstanceConstraints struct {
+	Pool string
+	Size uint64
 }

--- a/model.go
+++ b/model.go
@@ -701,7 +701,7 @@ func (m *model) AddStorage(args StorageArgs) Storage {
 
 func (m *model) setStorages(storageList []*storage) {
 	m.Storages_ = storages{
-		Version:   2,
+		Version:   3,
 		Storages_: storageList,
 	}
 }

--- a/storage_test.go
+++ b/storage_test.go
@@ -39,6 +39,10 @@ func testStorageMap() map[interface{}]interface{} {
 			"postgresql/0",
 			"postgresql/1",
 		},
+		"constraints": map[string]interface{}{
+			"pool": "radiance",
+			"size": 1234,
+		},
 	}
 }
 
@@ -56,6 +60,10 @@ func testStorageArgs() StorageArgs {
 		Attachments: []names.UnitTag{
 			names.NewUnitTag("postgresql/0"),
 			names.NewUnitTag("postgresql/1"),
+		},
+		Constraints: &StorageInstanceConstraints{
+			Pool: "radiance",
+			Size: 1234,
 		},
 	}
 }
@@ -124,6 +132,7 @@ func (s *StorageSerializationSuite) exportImport(c *gc.C, storage_ *storage, ver
 
 func (s *StorageSerializationSuite) TestParsingSerializedDataV1(c *gc.C) {
 	original := testStorage()
+	original.Constraints_ = nil
 	storage := s.exportImport(c, original, 1)
 	c.Assert(storage, jc.DeepEquals, original)
 }
@@ -132,6 +141,15 @@ func (s *StorageSerializationSuite) TestParsingSerializedDataV2(c *gc.C) {
 	original := testStorage()
 	original.Owner_ = ""
 	original.Attachments_ = nil
+	original.Constraints_ = nil
 	storage := s.exportImport(c, original, 2)
+	c.Assert(storage, jc.DeepEquals, original)
+}
+
+func (s *StorageSerializationSuite) TestParsingSerializedDataV3(c *gc.C) {
+	original := testStorage()
+	original.Owner_ = ""
+	original.Attachments_ = nil
+	storage := s.exportImport(c, original, 3)
 	c.Assert(storage, jc.DeepEquals, original)
 }


### PR DESCRIPTION
Storage instances now record the storage constraints
that were used to create them, so that we can create
the volume/filesystem when assigning the storage's
owner unit to a machine.