### PR TITLE
Remote application schema changes, remove limit/scope from endpoint, rename offername->offeruuid

### DIFF
--- a/model_test.go
+++ b/model_test.go
@@ -679,7 +679,7 @@ func (s *ModelSerializationSuite) TestModelValidationHandlesRemoteApplications(c
 	model := s.newModel(ModelArgs{Owner: names.NewUserTag("ink-spots")})
 	remoteApp := model.AddRemoteApplication(RemoteApplicationArgs{
 		Tag:             names.NewApplicationTag("mysql"),
-		OfferName:       "mysql",
+		OfferUUID:       "offer-uuid",
 		URL:             "other.mysql",
 		SourceModel:     names.NewModelTag("some-model"),
 		IsConsumerProxy: true,
@@ -688,7 +688,6 @@ func (s *ModelSerializationSuite) TestModelValidationHandlesRemoteApplications(c
 		Name:      "db",
 		Role:      "provider",
 		Interface: "mysql",
-		Scope:     "global",
 	})
 
 	s.addApplicationToModel(model, "wordpress", 1)
@@ -729,7 +728,7 @@ func (s *ModelSerializationSuite) TestSerializesRemoteApplications(c *gc.C) {
 	model := s.newModel(ModelArgs{Owner: names.NewUserTag("veils")})
 	rapp := model.AddRemoteApplication(RemoteApplicationArgs{
 		Tag:             names.NewApplicationTag("bloom"),
-		OfferName:       "toman",
+		OfferUUID:       "offer-uuid",
 		URL:             "other.mysql",
 		SourceModel:     names.NewModelTag("some-model"),
 		IsConsumerProxy: true,
@@ -738,7 +737,6 @@ func (s *ModelSerializationSuite) TestSerializesRemoteApplications(c *gc.C) {
 		Name:      "db",
 		Role:      "provider",
 		Interface: "mysql",
-		Scope:     "global",
 	})
 	rapp.SetStatus(StatusArgs{
 		Value:   "running",
@@ -757,14 +755,12 @@ remote-applications:
 - endpoints:
     endpoints:
     - interface: mysql
-      limit: 0
       name: db
       role: provider
-      scope: global
     version: 1
   is-consumer-proxy: true
   name: bloom
-  offer-name: toman
+  offer-uuid: offer-uuid
   source-model-uuid: some-model
   spaces:
     spaces: []
@@ -784,7 +780,7 @@ func (s *ModelSerializationSuite) TestImportingWithRemoteApplications(c *gc.C) {
 	initial := s.newModel(ModelArgs{Owner: names.NewUserTag("veils")})
 	rapp := initial.AddRemoteApplication(RemoteApplicationArgs{
 		Tag:             names.NewApplicationTag("bloom"),
-		OfferName:       "toman",
+		OfferUUID:       "offer-uuid",
 		URL:             "other.mysql",
 		SourceModel:     names.NewModelTag("some-model"),
 		IsConsumerProxy: true,
@@ -793,7 +789,6 @@ func (s *ModelSerializationSuite) TestImportingWithRemoteApplications(c *gc.C) {
 		Name:      "db",
 		Role:      "provider",
 		Interface: "mysql",
-		Scope:     "global",
 	})
 	rapp.SetStatus(StatusArgs{
 		Value:   "hey",
@@ -815,7 +810,7 @@ func (s *ModelSerializationSuite) TestRemoteApplicationsGetter(c *gc.C) {
 	model := s.newModel(ModelArgs{Owner: names.NewUserTag("veils")})
 	model.AddRemoteApplication(RemoteApplicationArgs{
 		Tag:             names.NewApplicationTag("bloom"),
-		OfferName:       "toman",
+		OfferUUID:       "offer-uuid",
 		URL:             "other.mysql",
 		SourceModel:     names.NewModelTag("some-model"),
 		IsConsumerProxy: true,
@@ -906,7 +901,7 @@ func (s *ModelSerializationSuite) TestVersion1IgnoresRemoteApplications(c *gc.C)
 	initial := s.newModel(ModelArgs{Owner: names.NewUserTag("ben-harper")})
 	initial.AddRemoteApplication(RemoteApplicationArgs{
 		Tag:             names.NewApplicationTag("bloom"),
-		OfferName:       "toman",
+		OfferUUID:       "offer-uuid",
 		URL:             "other.mysql",
 		SourceModel:     names.NewModelTag("some-model"),
 		IsConsumerProxy: true,

--- a/remoteapplication.go
+++ b/remoteapplication.go
@@ -16,7 +16,7 @@ type RemoteApplication interface {
 
 	Tag() names.ApplicationTag
 	Name() string
-	OfferName() string
+	OfferUUID() string
 	URL() string
 	SourceModelTag() names.ModelTag
 	IsConsumerProxy() bool
@@ -37,7 +37,7 @@ type remoteApplications struct {
 
 type remoteApplication struct {
 	Name_            string            `yaml:"name"`
-	OfferName_       string            `yaml:"offer-name"`
+	OfferUUID_       string            `yaml:"offer-uuid"`
 	URL_             string            `yaml:"url"`
 	SourceModelUUID_ string            `yaml:"source-model-uuid"`
 	Endpoints_       remoteEndpoints   `yaml:"endpoints,omitempty"`
@@ -51,7 +51,7 @@ type remoteApplication struct {
 // application to the Model.
 type RemoteApplicationArgs struct {
 	Tag             names.ApplicationTag
-	OfferName       string
+	OfferUUID       string
 	URL             string
 	SourceModel     names.ModelTag
 	IsConsumerProxy bool
@@ -61,7 +61,7 @@ type RemoteApplicationArgs struct {
 func newRemoteApplication(args RemoteApplicationArgs) *remoteApplication {
 	a := &remoteApplication{
 		Name_:            args.Tag.Id(),
-		OfferName_:       args.OfferName,
+		OfferUUID_:       args.OfferUUID,
 		URL_:             args.URL,
 		SourceModelUUID_: args.SourceModel.Id(),
 		IsConsumerProxy_: args.IsConsumerProxy,
@@ -82,9 +82,9 @@ func (a *remoteApplication) Name() string {
 	return a.Name_
 }
 
-// OfferName implements RemoteApplication.
-func (a *remoteApplication) OfferName() string {
-	return a.OfferName_
+// OfferUUID implements RemoteApplication.
+func (a *remoteApplication) OfferUUID() string {
+	return a.OfferUUID_
 }
 
 // URL implements RemoteApplication.
@@ -214,7 +214,7 @@ func newRemoteApplicationFromValid(valid map[string]interface{}, version int) (*
 	// contains fields of the right type.
 	result := &remoteApplication{
 		Name_:            valid["name"].(string),
-		OfferName_:       valid["offer-name"].(string),
+		OfferUUID_:       valid["offer-uuid"].(string),
 		URL_:             valid["url"].(string),
 		SourceModelUUID_: valid["source-model-uuid"].(string),
 		IsConsumerProxy_: valid["is-consumer-proxy"].(bool),
@@ -253,7 +253,7 @@ func newRemoteApplicationFromValid(valid map[string]interface{}, version int) (*
 func remoteApplicationV1Fields() (schema.Fields, schema.Defaults) {
 	fields := schema.Fields{
 		"name":              schema.String(),
-		"offer-name":        schema.String(),
+		"offer-uuid":        schema.String(),
 		"url":               schema.String(),
 		"source-model-uuid": schema.String(),
 		"status":            schema.StringMap(schema.Any()),

--- a/remoteapplication_test.go
+++ b/remoteapplication_test.go
@@ -33,7 +33,7 @@ func (s *RemoteApplicationSerializationSuite) SetUpTest(c *gc.C) {
 func minimalRemoteApplicationMap() map[interface{}]interface{} {
 	return map[interface{}]interface{}{
 		"name":              "civil-wars",
-		"offer-name":        "barton-hollow",
+		"offer-uuid":        "offer-uuid",
 		"url":               "http://a.url",
 		"source-model-uuid": "abcd-1234",
 		"is-consumer-proxy": true,
@@ -54,8 +54,6 @@ func minimalRemoteApplicationMap() map[interface{}]interface{} {
 				"name":      "lana",
 				"role":      "provider",
 				"interface": "mysql",
-				"limit":     1,
-				"scope":     "global",
 			}},
 		},
 		"spaces": map[interface{}]interface{}{
@@ -90,7 +88,7 @@ func minimalRemoteApplicationMap() map[interface{}]interface{} {
 func minimalRemoteApplication() *remoteApplication {
 	a := newRemoteApplication(RemoteApplicationArgs{
 		Tag:             names.NewApplicationTag("civil-wars"),
-		OfferName:       "barton-hollow",
+		OfferUUID:       "offer-uuid",
 		URL:             "http://a.url",
 		SourceModel:     names.NewModelTag("abcd-1234"),
 		IsConsumerProxy: true,
@@ -108,8 +106,6 @@ func minimalRemoteApplication() *remoteApplication {
 		Name:      "lana",
 		Role:      "provider",
 		Interface: "mysql",
-		Limit:     1,
-		Scope:     "global",
 	})
 	space := a.AddSpace(RemoteSpaceArgs{
 		CloudType:  "gce",
@@ -133,7 +129,7 @@ func (*RemoteApplicationSerializationSuite) TestNew(c *gc.C) {
 	r := minimalRemoteApplication()
 	c.Check(r.Tag(), gc.Equals, names.NewApplicationTag("civil-wars"))
 	c.Check(r.Name(), gc.Equals, "civil-wars")
-	c.Check(r.OfferName(), gc.Equals, "barton-hollow")
+	c.Check(r.OfferUUID(), gc.Equals, "offer-uuid")
 	c.Check(r.URL(), gc.Equals, "http://a.url")
 	c.Check(r.SourceModelTag(), gc.Equals, names.NewModelTag("abcd-1234"))
 	c.Check(r.IsConsumerProxy(), jc.IsTrue)

--- a/remoteendpoint.go
+++ b/remoteendpoint.go
@@ -14,8 +14,6 @@ type RemoteEndpoint interface {
 	Name() string
 	Role() string
 	Interface() string
-	Limit() int
-	Scope() string
 }
 
 type remoteEndpoints struct {
@@ -27,8 +25,6 @@ type remoteEndpoint struct {
 	Name_      string `yaml:"name"`
 	Role_      string `yaml:"role"`
 	Interface_ string `yaml:"interface"`
-	Limit_     int    `yaml:"limit"`
-	Scope_     string `yaml:"scope"`
 }
 
 // RemoteEndpointArgs is an argument struct used to add a remote
@@ -37,8 +33,6 @@ type RemoteEndpointArgs struct {
 	Name      string
 	Role      string
 	Interface string
-	Limit     int
-	Scope     string
 }
 
 func newRemoteEndpoint(args RemoteEndpointArgs) *remoteEndpoint {
@@ -46,8 +40,6 @@ func newRemoteEndpoint(args RemoteEndpointArgs) *remoteEndpoint {
 		Name_:      args.Name,
 		Role_:      args.Role,
 		Interface_: args.Interface,
-		Limit_:     args.Limit,
-		Scope_:     args.Scope,
 	}
 }
 
@@ -64,16 +56,6 @@ func (e *remoteEndpoint) Role() string {
 // Interface implements RemoteEndpoint.
 func (e *remoteEndpoint) Interface() string {
 	return e.Interface_
-}
-
-// Limit implements RemoteEndpoint.
-func (e *remoteEndpoint) Limit() int {
-	return e.Limit_
-}
-
-// Scope implements RemoteEndpoint.
-func (e *remoteEndpoint) Scope() string {
-	return e.Scope_
 }
 
 func importRemoteEndpoints(sourceMap map[string]interface{}) ([]*remoteEndpoint, error) {
@@ -120,14 +102,9 @@ func importRemoteEndpointV1(source map[string]interface{}) (*remoteEndpoint, err
 		"name":      schema.String(),
 		"role":      schema.String(),
 		"interface": schema.String(),
-		"limit":     schema.Int(),
-		"scope":     schema.String(),
 	}
 
-	defaults := schema.Defaults{
-		"limit": 0,
-	}
-	checker := schema.FieldMap(fields, defaults)
+	checker := schema.FieldMap(fields, nil)
 
 	coerced, err := checker.Coerce(source, nil)
 	if err != nil {
@@ -140,8 +117,6 @@ func importRemoteEndpointV1(source map[string]interface{}) (*remoteEndpoint, err
 		Name_:      valid["name"].(string),
 		Role_:      valid["role"].(string),
 		Interface_: valid["interface"].(string),
-		Limit_:     int(valid["limit"].(int64)),
-		Scope_:     valid["scope"].(string),
 	}
 
 	return result, nil

--- a/remoteendpoint_test.go
+++ b/remoteendpoint_test.go
@@ -32,8 +32,6 @@ func minimalRemoteEndpointMap() map[interface{}]interface{} {
 		"name":      "lana",
 		"role":      "provider",
 		"interface": "mysql",
-		"limit":     1,
-		"scope":     "global",
 	}
 }
 
@@ -42,8 +40,6 @@ func minimalRemoteEndpoint() *remoteEndpoint {
 		Name:      "lana",
 		Role:      "provider",
 		Interface: "mysql",
-		Limit:     1,
-		Scope:     "global",
 	})
 }
 
@@ -52,8 +48,6 @@ func (*RemoteEndpointSerializationSuite) TestNew(c *gc.C) {
 	c.Check(r.Name(), gc.Equals, "lana")
 	c.Check(r.Role(), gc.Equals, "provider")
 	c.Check(r.Interface(), gc.Equals, "mysql")
-	c.Check(r.Limit(), gc.Equals, 1)
-	c.Check(r.Scope(), gc.Equals, "global")
 }
 
 func (*RemoteEndpointSerializationSuite) TestBadSchema1(c *gc.C) {
@@ -63,17 +57,6 @@ func (*RemoteEndpointSerializationSuite) TestBadSchema1(c *gc.C) {
 	}
 	_, err := importRemoteEndpoints(container)
 	c.Assert(err, gc.ErrorMatches, `remote endpoints version schema check failed: endpoints\[0\]: expected map, got int\(1234\)`)
-}
-
-func (*RemoteEndpointSerializationSuite) TestBadSchema2(c *gc.C) {
-	m := minimalRemoteEndpointMap()
-	m["limit"] = "blah"
-	container := map[string]interface{}{
-		"version":   1,
-		"endpoints": []interface{}{m},
-	}
-	_, err := importRemoteEndpoints(container)
-	c.Assert(err, gc.ErrorMatches, `remote endpoint 0: remote endpoint v1 schema check failed: limit: expected int, got string\("blah"\)`)
 }
 
 func (*RemoteEndpointSerializationSuite) TestMinimalMatches(c *gc.C) {


### PR DESCRIPTION
The remote application entity is changing:
- offer name becomes offer uuid
- remote endpoints drop limit and scope
