### PR TITLE
Add Endpoint.AllSettings

### DIFF
--- a/relation.go
+++ b/relation.go
@@ -206,6 +206,7 @@ type Endpoint interface {
 	// UnitCount returns the number of units the endpoint has settings for.
 	UnitCount() int
 
+	AllSettings() map[string]map[string]interface{}
 	Settings(unitName string) map[string]interface{}
 	SetUnitSettings(unitName string, settings map[string]interface{})
 }
@@ -297,6 +298,15 @@ func (e *endpoint) Scope() string {
 // UnitCount implements Endpoint.
 func (e *endpoint) UnitCount() int {
 	return len(e.UnitSettings_)
+}
+
+// AllSettings implements Endpoint.
+func (e *endpoint) AllSettings() map[string]map[string]interface{} {
+	result := make(map[string]map[string]interface{})
+	for name, settings := range e.UnitSettings_ {
+		result[name] = settings
+	}
+	return result
 }
 
 // Settings implements Endpoint.

--- a/relation_test.go
+++ b/relation_test.go
@@ -192,6 +192,16 @@ func (s *EndpointSerializationSuite) TestNewEndpoint(c *gc.C) {
 		"name": "unit two",
 		"foo":  "bar",
 	})
+	c.Assert(endpoint.AllSettings(), jc.DeepEquals, map[string]map[string]interface{}{
+		"ubuntu/0": {
+			"name": "unit one",
+			"key":  42,
+		},
+		"ubuntu/1": {
+			"name": "unit two",
+			"foo":  "bar",
+		},
+	})
 }
 
 func (s *EndpointSerializationSuite) TestMinimalMatches(c *gc.C) {


### PR DESCRIPTION
This will be used in importing so that we can loop over all settings for
the relation, rather than needing to loop over all units for the
application - not all of them will be valid for this endpoint.

Part of fixing: https://bugs.launchpad.net/juju/+bug/1715794