### PR TITLE
Fix Model.Validate for ownerless storage

### DIFF
--- a/model.go
+++ b/model.go
@@ -876,9 +876,11 @@ func (m *model) validateStorage(allMachineIDs, allApplications, allUnits set.Str
 		if err != nil {
 			return errors.Wrap(err, errors.NotValidf("storage[%d] owner (%s)", i, owner))
 		}
-		ownerID := owner.Id()
-		if !appsAndUnits.Contains(ownerID) {
-			return errors.NotValidf("storage[%d] owner (%s)", i, ownerID)
+		if owner != nil {
+			ownerID := owner.Id()
+			if !appsAndUnits.Contains(ownerID) {
+				return errors.NotValidf("storage[%d] owner (%s)", i, ownerID)
+			}
 		}
 		for _, unit := range storage.Attachments() {
 			if !allUnits.Contains(unit.Id()) {

--- a/model_test.go
+++ b/model_test.go
@@ -1140,6 +1140,19 @@ func (s *ModelSerializationSuite) TestStorage(c *gc.C) {
 	c.Assert(model.Storages(), jc.DeepEquals, storages)
 }
 
+func (s *ModelSerializationSuite) TestStorageValidate(c *gc.C) {
+	initial := s.newModel(ModelArgs{Owner: names.NewUserTag("owner")})
+	storageArgs := testStorageArgs()
+	storageArgs.Owner = nil
+	storage := initial.AddStorage(storageArgs)
+	storages := initial.Storages()
+	c.Assert(storages, gc.HasLen, 1)
+	c.Assert(storages[0], jc.DeepEquals, storage)
+
+	err := initial.Validate()
+	c.Assert(err, gc.ErrorMatches, `storage\[0\] attachment referencing unknown unit "unit-postgresql-0" not valid`)
+}
+
 func (s *ModelSerializationSuite) TestStoragePools(c *gc.C) {
 	initial := s.newModel(ModelArgs{Owner: names.NewUserTag("owner")})
 	poolOne := map[string]interface{}{


### PR DESCRIPTION
model.validateStorage would panic if any of
the storage instances within the model did
not have an owner. This is now fixed, so
the owner field is nil-checked (and ignored
if nil) before dereferencing.