### PR TITLE
New version of applications format to add application type field.

### DIFF
--- a/model.go
+++ b/model.go
@@ -390,7 +390,7 @@ func (m *model) AddApplication(args ApplicationArgs) Application {
 
 func (m *model) setApplications(applicationList []*application) {
 	m.Applications_ = applications{
-		Version:       1,
+		Version:       2,
 		Applications_: applicationList,
 	}
 }


### PR DESCRIPTION
Juju needs to distinguish between different types of applications, which reveal the type of the underlying execution framework. This adds a string key to application and increments the format version for applications.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>