### PR TITLE
Add IsDefaultGateway field to IpAddress

### DIFF
--- a/model.go
+++ b/model.go
@@ -505,7 +505,7 @@ func (m *model) AddIPAddress(args IPAddressArgs) IPAddress {
 
 func (m *model) setIPAddresses(addressesList []*ipaddress) {
 	m.IPAddresses_ = ipaddresses{
-		Version:      1,
+		Version:      2,
 		IPAddresses_: addressesList,
 	}
 }

--- a/model_test.go
+++ b/model_test.go
@@ -561,11 +561,12 @@ func (s *ModelSerializationSuite) TestModelValidationChecksAddressGatewayAddress
 func (s *ModelSerializationSuite) TestModelValidationChecksAddressGatewayAddressValid(c *gc.C) {
 	model := s.newModel(ModelArgs{Owner: names.NewUserTag("owner")})
 	args := IPAddressArgs{
-		MachineID:      "42",
-		DeviceName:     "foo",
-		Value:          "192.168.1.2",
-		SubnetCIDR:     "192.168.1.0/24",
-		GatewayAddress: "192.168.1.1",
+		MachineID:        "42",
+		DeviceName:       "foo",
+		Value:            "192.168.1.2",
+		SubnetCIDR:       "192.168.1.0/24",
+		GatewayAddress:   "192.168.1.1",
+		IsDefaultGateway: true,
 	}
 	model.AddIPAddress(args)
 	s.addMachineToModel(model, "42")


### PR DESCRIPTION
IsDefaultGateway field in IpAddress structure marks an address on an interface that's used as a default gw for a machine, as reported by machiner worker.