### PR TITLE
Add support for application config

### DIFF
--- a/model.go
+++ b/model.go
@@ -390,7 +390,7 @@ func (m *model) AddApplication(args ApplicationArgs) Application {
 
 func (m *model) setApplications(applicationList []*application) {
 	m.Applications_ = applications{
-		Version:       2,
+		Version:       3,
 		Applications_: applicationList,
 	}
 }

--- a/model_test.go
+++ b/model_test.go
@@ -315,7 +315,7 @@ func (s *ModelSerializationSuite) TestModelValidationChecksApplications(c *gc.C)
 func (s *ModelSerializationSuite) addApplicationToModel(model Model, name string, numUnits int) Application {
 	application := model.AddApplication(ApplicationArgs{
 		Tag:                names.NewApplicationTag(name),
-		Settings:           map[string]interface{}{},
+		CharmConfig:        map[string]interface{}{},
 		LeadershipSettings: map[string]interface{}{},
 	})
 	application.SetStatus(minimalStatusArgs())


### PR DESCRIPTION
The application entity gains an optional "application-config" field. These configs are for the application itself, as opposed to those for the charm which it manages. The serialisation version is incremented to 3.