### PR TITLE
Use proper address structs for cloud containers, not just strings

### DIFF
--- a/application.go
+++ b/application.go
@@ -117,7 +117,7 @@ type ApplicationArgs struct {
 	ForceCharm           bool
 	PasswordHash         string
 	PodSpec              string
-	CloudService         *cloudService
+	CloudService         *CloudServiceArgs
 	Exposed              bool
 	MinUnits             int
 	EndpointBindings     map[string]string
@@ -143,7 +143,7 @@ func newApplication(args ApplicationArgs) *application {
 		Exposed_:              args.Exposed,
 		PasswordHash_:         args.PasswordHash,
 		PodSpec_:              args.PodSpec,
-		CloudService_:         args.CloudService,
+		CloudService_:         newCloudService(args.CloudService),
 		MinUnits_:             args.MinUnits,
 		EndpointBindings_:     args.EndpointBindings,
 		ApplicationConfig_:    args.ApplicationConfig,
@@ -341,7 +341,7 @@ func (a *application) CloudService() CloudService {
 
 // SetCloudService implements Application.
 func (a *application) SetCloudService(args CloudServiceArgs) {
-	a.CloudService_ = newCloudService(args)
+	a.CloudService_ = newCloudService(&args)
 }
 
 // Resources implements Application.

--- a/cloudcontainer_test.go
+++ b/cloudcontainer_test.go
@@ -23,7 +23,7 @@ func (s *CloudContainerSerializationSuite) SetUpTest(c *gc.C) {
 	}
 	s.testFields = func(m map[string]interface{}) {
 		m["provider-id"] = ""
-		m["address"] = ""
+		m["address"] = map[string]interface{}{}
 		m["ports"] = ""
 	}
 }
@@ -31,23 +31,24 @@ func (s *CloudContainerSerializationSuite) SetUpTest(c *gc.C) {
 func (*CloudContainerSerializationSuite) allArgs() CloudContainerArgs {
 	return CloudContainerArgs{
 		ProviderId: "some-provider",
-		Address:    "10.0.0.1",
+		Address:    AddressArgs{Value: "10.0.0.1", Type: "special"},
 		Ports:      []string{"80", "443"},
 	}
 }
 
 func (s *CloudContainerSerializationSuite) TestAllArgs(c *gc.C) {
 	args := s.allArgs()
-	container := newCloudContainer(args)
+	container := newCloudContainer(&args)
 
 	c.Check(container.ProviderId(), gc.Equals, args.ProviderId)
-	c.Check(container.Address(), gc.Equals, args.Address)
+	c.Check(container.Address(), jc.DeepEquals, &address{Version: 1, Value_: "10.0.0.1", Type_: "special"})
+
 	c.Check(container.Ports(), jc.DeepEquals, args.Ports)
 }
 
 func (s *CloudContainerSerializationSuite) TestParsingSerializedData(c *gc.C) {
 	args := s.allArgs()
-	initial := newCloudContainer(args)
+	initial := newCloudContainer(&args)
 
 	bytes, err := yaml.Marshal(initial)
 	c.Assert(err, jc.ErrorIsNil)

--- a/cloudservice_test.go
+++ b/cloudservice_test.go
@@ -23,14 +23,17 @@ func (s *CloudServiceSerializationSuite) SetUpTest(c *gc.C) {
 	}
 	s.testFields = func(m map[string]interface{}) {
 		m["provider-id"] = ""
-		m["addresses"] = ""
+		m["addresses"] = []interface{}{}
 	}
 }
 
-func (*CloudServiceSerializationSuite) allArgs() CloudServiceArgs {
-	return CloudServiceArgs{
+func (*CloudServiceSerializationSuite) allArgs() *CloudServiceArgs {
+	return &CloudServiceArgs{
 		ProviderId: "provider-id",
-		Addresses:  []string{"10.0.0.1", "10.0.0.2"},
+		Addresses: []AddressArgs{
+			{Value: "10.0.0.1", Type: "special"},
+			{Value: "10.0.0.2", Type: "other"},
+		},
 	}
 }
 
@@ -39,7 +42,10 @@ func (s *CloudServiceSerializationSuite) TestAllArgs(c *gc.C) {
 	container := newCloudService(args)
 
 	c.Check(container.ProviderId(), gc.Equals, args.ProviderId)
-	c.Check(container.Addresses(), jc.DeepEquals, args.Addresses)
+	c.Check(container.Addresses(), jc.DeepEquals, []Address{
+		&address{Version: 1, Value_: "10.0.0.1", Type_: "special"},
+		&address{Version: 1, Value_: "10.0.0.2", Type_: "other"},
+	})
 }
 
 func (s *CloudServiceSerializationSuite) TestParsingSerializedData(c *gc.C) {

--- a/interfaces.go
+++ b/interfaces.go
@@ -243,16 +243,3 @@ type StorageInstanceConstraints struct {
 	Pool string
 	Size uint64
 }
-
-// CloudContainer represents the state of a CAAS container, eg pod.
-type CloudContainer interface {
-	ProviderId() string
-	Address() string
-	Ports() []string
-}
-
-// CloudService represents the state of a CAAS service.
-type CloudService interface {
-	ProviderId() string
-	Addresses() []string
-}

--- a/unit.go
+++ b/unit.go
@@ -60,7 +60,7 @@ type UnitArgs struct {
 	MeterStatusCode string
 	MeterStatusInfo string
 
-	CloudContainer *cloudContainer
+	CloudContainer *CloudContainerArgs
 
 	// TODO: storage attachment count
 }
@@ -74,7 +74,7 @@ func newUnit(args UnitArgs) *unit {
 		Name_:                   args.Tag.Id(),
 		Machine_:                args.Machine.Id(),
 		PasswordHash_:           args.PasswordHash,
-		CloudContainer_:         args.CloudContainer,
+		CloudContainer_:         newCloudContainer(args.CloudContainer),
 		Principal_:              args.Principal.Id(),
 		Subordinates_:           subordinates,
 		WorkloadVersion_:        args.WorkloadVersion,
@@ -223,7 +223,7 @@ func (u *unit) CloudContainer() CloudContainer {
 
 // SetCloudContainer implements Unit.
 func (u *unit) SetCloudContainer(args CloudContainerArgs) {
-	u.CloudContainer_ = newCloudContainer(args)
+	u.CloudContainer_ = newCloudContainer(&args)
 }
 
 // Constraints implements HasConstraints.

--- a/unit_test.go
+++ b/unit_test.go
@@ -50,9 +50,17 @@ func minimalUnitMap() map[interface{}]interface{} {
 		"cloud-container": map[interface{}]interface{}{
 			"version":     1,
 			"provider-id": "some-provider",
-			"address":     "10.0.0.1",
+			"address":     map[interface{}]interface{}{"version": 1, "value": "10.0.0.1", "type": "special"},
 			"ports":       []interface{}{"80", "443"},
 		},
+	}
+}
+
+func minimalCloudContainerArgs() CloudContainerArgs {
+	return CloudContainerArgs{
+		ProviderId: "some-provider",
+		Address:    AddressArgs{Value: "10.0.0.1", Type: "special"},
+		Ports:      []string{"80", "443"},
 	}
 }
 
@@ -61,7 +69,6 @@ func minimalUnit() *unit {
 	u.SetAgentStatus(minimalStatusArgs())
 	u.SetWorkloadStatus(minimalStatusArgs())
 	u.SetTools(minimalAgentToolsArgs())
-	u.SetCloudContainer(minimalCloudContainerArgs())
 	return u
 }
 
@@ -70,11 +77,10 @@ func minimalUnitArgs() UnitArgs {
 		Tag:          names.NewUnitTag("ubuntu/0"),
 		Machine:      names.NewMachineTag("0"),
 		PasswordHash: "secure-hash",
-		CloudContainer: &cloudContainer{
-			Version:     1,
-			ProviderId_: "some-provider",
-			Address_:    "10.0.0.1",
-			Ports_:      []string{"80", "443"},
+		CloudContainer: &CloudContainerArgs{
+			ProviderId: "some-provider",
+			Address:    AddressArgs{Value: "10.0.0.1", Type: "special"},
+			Ports:      []string{"80", "443"},
 		},
 	}
 }
@@ -209,13 +215,13 @@ func (s *UnitSerializationSuite) TestCloudContainer(c *gc.C) {
 	initial := minimalUnit()
 	args := CloudContainerArgs{
 		ProviderId: "some-provider",
-		Address:    "10.0.0.1",
+		Address:    AddressArgs{Value: "10.0.0.1", Type: "special"},
 		Ports:      []string{"80", "443"},
 	}
 	initial.SetCloudContainer(args)
 
 	unit := s.exportImportLatest(c, initial)
-	c.Assert(unit.CloudContainer(), jc.DeepEquals, newCloudContainer(args))
+	c.Assert(unit.CloudContainer(), jc.DeepEquals, newCloudContainer(&args))
 }
 
 func (s *UnitSerializationSuite) TestAgentStatusHistory(c *gc.C) {


### PR DESCRIPTION
The CAAS structs which contain addresses should have used proper address structs rather than just strings. This PR fixes that issue. It also allows an args struct to be used to construct the application and unit objects so that juju export can work as expected.