### PR TITLE
caas units do not require tools metadata

### DIFF
--- a/application.go
+++ b/application.go
@@ -395,7 +395,7 @@ func (a *application) Validate() error {
 		return errors.NotValidf("application %q missing status", a.Name_)
 	}
 
-	if a.Tools_ == nil && a.Type_ == "caas" {
+	if a.Tools_ == nil && a.Type_ == CAAS {
 		return errors.NotValidf("application %q missing tools", a.Name_)
 	}
 
@@ -551,7 +551,7 @@ func importApplication(fields schema.Fields, defaults schema.Defaults, importVer
 	result := &application{
 		Name_:                 valid["name"].(string),
 		Series_:               valid["series"].(string),
-		Type_:                 "iaas",
+		Type_:                 IAAS,
 		Subordinate_:          valid["subordinate"].(bool),
 		CharmURL_:             valid["charm-url"].(string),
 		Channel_:              valid["cs-channel"].(string),
@@ -614,7 +614,7 @@ func importApplication(fields schema.Fields, defaults schema.Defaults, importVer
 
 	toolsMap, ok := valid["tools"].(map[string]interface{})
 	// CAAS models require tools.
-	if importVersion >= 3 && !ok && result.Type_ == "caas" {
+	if importVersion >= 3 && !ok && result.Type_ == CAAS {
 		return nil, errors.NotFoundf("tools metadata in CAAS model")
 	}
 	if ok {

--- a/application.go
+++ b/application.go
@@ -395,6 +395,10 @@ func (a *application) Validate() error {
 		return errors.NotValidf("application %q missing status", a.Name_)
 	}
 
+	if a.Tools_ == nil && a.Type_ == "caas" {
+		return errors.NotValidf("application %q missing tools", a.Name_)
+	}
+
 	for _, resource := range a.Resources_.Resources_ {
 		if err := resource.Validate(); err != nil {
 			return errors.Annotatef(err, "resource %s", resource.Name_)
@@ -644,6 +648,16 @@ func importApplication(fields schema.Fields, defaults schema.Defaults, importVer
 	units, err := importUnits(valid["units"].(map[string]interface{}))
 	if err != nil {
 		return nil, errors.Trace(err)
+	}
+	// Units inherit model type from their application.
+	for _, u := range units {
+		u.Type_ = result.Type_
+
+		// Validate to ensure expected type specific
+		// attributes like tools are set.
+		if err := u.Validate(); err != nil {
+			return nil, errors.Trace(err)
+		}
 	}
 	result.setUnits(units)
 

--- a/application_test.go
+++ b/application_test.go
@@ -39,7 +39,7 @@ func minimalApplicationMap() map[interface{}]interface{} {
 	return map[interface{}]interface{}{
 		"name":              "ubuntu",
 		"series":            "trusty",
-		"type":              "iaas",
+		"type":              IAAS,
 		"charm-url":         "cs:trusty/ubuntu",
 		"cs-channel":        "stable",
 		"charm-mod-version": 1,
@@ -70,7 +70,7 @@ func minimalApplicationMap() map[interface{}]interface{} {
 
 func minimalApplicationMapCAAS() map[interface{}]interface{} {
 	result := minimalApplicationMap()
-	result["type"] = "caas"
+	result["type"] = CAAS
 	result["password-hash"] = "some-hash"
 	result["pod-spec"] = "some-spec"
 	result["cloud-service"] = map[interface{}]interface{}{
@@ -93,7 +93,7 @@ func minimalApplicationMapCAAS() map[interface{}]interface{} {
 
 func minimalApplication(args ...ApplicationArgs) *application {
 	if len(args) == 0 {
-		args = []ApplicationArgs{minimalApplicationArgs("iaas")}
+		args = []ApplicationArgs{minimalApplicationArgs(IAAS)}
 	}
 	a := newApplication(args[0])
 	a.SetStatus(minimalStatusArgs())
@@ -101,7 +101,7 @@ func minimalApplication(args ...ApplicationArgs) *application {
 	u.SetAgentStatus(minimalStatusArgs())
 	u.SetWorkloadStatus(minimalStatusArgs())
 	a.setResources([]*resource{minimalResource()})
-	if a.Type_ == "caas" {
+	if a.Type_ == CAAS {
 		a.SetTools(minimalAgentToolsArgs())
 	} else {
 		u.SetTools(minimalAgentToolsArgs())
@@ -110,7 +110,7 @@ func minimalApplication(args ...ApplicationArgs) *application {
 }
 
 func addMinimalApplication(model Model) {
-	a := model.AddApplication(minimalApplicationArgs("iaas"))
+	a := model.AddApplication(minimalApplicationArgs(IAAS))
 	a.SetStatus(minimalStatusArgs())
 	u := a.AddUnit(minimalUnitArgs(a.Type()))
 	u.SetAgentStatus(minimalStatusArgs())
@@ -135,7 +135,7 @@ func minimalApplicationArgs(modelType string) ApplicationArgs {
 		},
 		MetricsCredentials: []byte("sekrit"),
 	}
-	if modelType == "caas" {
+	if modelType == CAAS {
 		result.PasswordHash = "some-hash"
 		result.PodSpec = "some-spec"
 		result.CloudService = &CloudServiceArgs{
@@ -207,12 +207,12 @@ func (s *ApplicationSerializationSuite) TestMinimalApplicationValid(c *gc.C) {
 }
 
 func (s *ApplicationSerializationSuite) TestMinimalCAASApplicationValid(c *gc.C) {
-	application := minimalApplication(minimalApplicationArgs("caas"))
+	application := minimalApplication(minimalApplicationArgs(CAAS))
 	c.Assert(application.Validate(), jc.ErrorIsNil)
 }
 
 func (s *ApplicationSerializationSuite) TestMinimalMatchesCAAS(c *gc.C) {
-	args := minimalApplicationArgs("caas")
+	args := minimalApplicationArgs(CAAS)
 	bytes, err := yaml.Marshal(minimalApplication(args))
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -256,7 +256,7 @@ func (s *ApplicationSerializationSuite) exportImportLatest(c *gc.C, application_
 }
 
 func (s *ApplicationSerializationSuite) TestV1ParsingReturnsLatest(c *gc.C) {
-	args := minimalApplicationArgs("caas")
+	args := minimalApplicationArgs(CAAS)
 	args.Type = ""
 	appV1 := minimalApplication(args)
 
@@ -272,7 +272,7 @@ func (s *ApplicationSerializationSuite) TestV1ParsingReturnsLatest(c *gc.C) {
 }
 
 func (s *ApplicationSerializationSuite) TestV2ParsingReturnsLatest(c *gc.C) {
-	args := minimalApplicationArgs("caas")
+	args := minimalApplicationArgs(CAAS)
 	appV1 := minimalApplication(args)
 
 	// Make an app with fields not in v2 removed.
@@ -293,7 +293,7 @@ func (s *ApplicationSerializationSuite) TestParsingSerializedData(c *gc.C) {
 }
 
 func (s *ApplicationSerializationSuite) TestEndpointBindings(c *gc.C) {
-	args := minimalApplicationArgs("iaas")
+	args := minimalApplicationArgs(IAAS)
 	args.EndpointBindings = map[string]string{
 		"rel-name": "some-space",
 		"other":    "other-space",
@@ -329,7 +329,7 @@ func (s *ApplicationSerializationSuite) TestConstraints(c *gc.C) {
 }
 
 func (s *ApplicationSerializationSuite) TestStorageConstraints(c *gc.C) {
-	args := minimalApplicationArgs("iaas")
+	args := minimalApplicationArgs(IAAS)
 	args.StorageConstraints = map[string]StorageConstraintArgs{
 		"first":  {Pool: "first", Size: 1234, Count: 1},
 		"second": {Pool: "second", Size: 4321, Count: 7},
@@ -354,7 +354,7 @@ func (s *ApplicationSerializationSuite) TestStorageConstraints(c *gc.C) {
 }
 
 func (s *ApplicationSerializationSuite) TestApplicationConfig(c *gc.C) {
-	args := minimalApplicationArgs("caas")
+	args := minimalApplicationArgs(CAAS)
 	args.ApplicationConfig = map[string]interface{}{
 		"first":  "value 1",
 		"second": 42,
@@ -369,7 +369,7 @@ func (s *ApplicationSerializationSuite) TestApplicationConfig(c *gc.C) {
 }
 
 func (s *ApplicationSerializationSuite) TestPasswordHash(c *gc.C) {
-	args := minimalApplicationArgs("caas")
+	args := minimalApplicationArgs(CAAS)
 	args.PasswordHash = "passwordhash"
 	initial := minimalApplication(args)
 
@@ -378,7 +378,7 @@ func (s *ApplicationSerializationSuite) TestPasswordHash(c *gc.C) {
 }
 
 func (s *ApplicationSerializationSuite) TestPodSpec(c *gc.C) {
-	args := minimalApplicationArgs("caas")
+	args := minimalApplicationArgs(CAAS)
 	args.PodSpec = "podspec"
 	initial := minimalApplication(args)
 
@@ -387,7 +387,7 @@ func (s *ApplicationSerializationSuite) TestPodSpec(c *gc.C) {
 }
 
 func (s *ApplicationSerializationSuite) TestCloudService(c *gc.C) {
-	args := minimalApplicationArgs("caas")
+	args := minimalApplicationArgs(CAAS)
 	initial := minimalApplication(args)
 	serviceArgs := CloudServiceArgs{
 		ProviderId: "some-provider",
@@ -403,7 +403,7 @@ func (s *ApplicationSerializationSuite) TestCloudService(c *gc.C) {
 }
 
 func (s *ApplicationSerializationSuite) TestLeaderValid(c *gc.C) {
-	args := minimalApplicationArgs("iaas")
+	args := minimalApplicationArgs(IAAS)
 	args.Leader = "ubuntu/1"
 	application := newApplication(args)
 	application.SetStatus(minimalStatusArgs())
@@ -420,14 +420,14 @@ func (s *ApplicationSerializationSuite) TestResourcesAreValidated(c *gc.C) {
 }
 
 func (s *ApplicationSerializationSuite) TestCAASMissingToolsValidated(c *gc.C) {
-	app := minimalApplication(minimalApplicationArgs("caas"))
+	app := minimalApplication(minimalApplicationArgs(CAAS))
 	app.Tools_ = nil
 	err := app.Validate()
 	c.Assert(err, gc.ErrorMatches, `application "ubuntu" missing tools not valid`)
 }
 
 func (s *ApplicationSerializationSuite) TestCAASApplicationMissingTools(c *gc.C) {
-	app := minimalApplication(minimalApplicationArgs("caas"))
+	app := minimalApplication(minimalApplicationArgs(CAAS))
 	app.Tools_ = nil
 	initial := applications{
 		Version:       3,

--- a/interfaces.go
+++ b/interfaces.go
@@ -19,55 +19,6 @@ type AgentTools interface {
 	Size() int64
 }
 
-// Unit represents an instance of a unit in a model.
-type Unit interface {
-	HasAnnotations
-	HasConstraints
-
-	Tag() names.UnitTag
-	Name() string
-	Machine() names.MachineTag
-
-	PasswordHash() string
-
-	Principal() names.UnitTag
-	Subordinates() []names.UnitTag
-
-	MeterStatusCode() string
-	MeterStatusInfo() string
-
-	Tools() AgentTools
-	SetTools(AgentToolsArgs)
-
-	WorkloadStatus() Status
-	SetWorkloadStatus(StatusArgs)
-
-	WorkloadStatusHistory() []Status
-	SetWorkloadStatusHistory([]StatusArgs)
-
-	WorkloadVersion() string
-
-	WorkloadVersionHistory() []Status
-	SetWorkloadVersionHistory([]StatusArgs)
-
-	AgentStatus() Status
-	SetAgentStatus(StatusArgs)
-
-	AgentStatusHistory() []Status
-	SetAgentStatusHistory([]StatusArgs)
-
-	AddResource(UnitResourceArgs) UnitResource
-	Resources() []UnitResource
-
-	AddPayload(PayloadArgs) Payload
-	Payloads() []Payload
-
-	CloudContainer() CloudContainer
-	SetCloudContainer(CloudContainerArgs)
-
-	Validate() error
-}
-
 // Space represents a network space, which is a named collection of subnets.
 type Space interface {
 	Name() string

--- a/model.go
+++ b/model.go
@@ -17,6 +17,14 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+const (
+	// IAAS is the type for IAAS models.
+	IAAS = "iaas"
+
+	// CAAS is the type for CAAS models.
+	CAAS = "caas"
+)
+
 // Model is a database agnostic representation of an existing model.
 type Model interface {
 	HasAnnotations
@@ -1192,7 +1200,7 @@ func newModelFromValid(valid map[string]interface{}, importVersion int) (*model,
 	// the way in.
 	result := &model{
 		Version:        4,
-		Type_:          "iaas",
+		Type_:          IAAS,
 		Owner_:         valid["owner"].(string),
 		Config_:        valid["config"].(map[string]interface{}),
 		Sequences_:     make(map[string]int),

--- a/model_test.go
+++ b/model_test.go
@@ -127,7 +127,7 @@ func (s *ModelSerializationSuite) TestParsingModelV1(c *gc.C) {
 
 func (s *ModelSerializationSuite) TestParsingYAML(c *gc.C) {
 	args := ModelArgs{
-		Type:  "iaas",
+		Type:  IAAS,
 		Owner: names.NewUserTag("magic"),
 		Config: map[string]interface{}{
 			"name": "awesome",
@@ -158,7 +158,7 @@ func (s *ModelSerializationSuite) TestParsingYAML(c *gc.C) {
 	addMinimalApplication(initial)
 	model := s.exportImport(c, initial)
 
-	c.Assert(model.Type(), gc.Equals, "iaas")
+	c.Assert(model.Type(), gc.Equals, IAAS)
 	c.Assert(model.Owner(), gc.Equals, args.Owner)
 	c.Assert(model.Tag().Id(), gc.Equals, "some-uuid")
 	c.Assert(model.Config(), jc.DeepEquals, args.Config)
@@ -898,7 +898,7 @@ func (s *ModelSerializationSuite) TestVersion1Works(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(model.Owner(), gc.Equals, names.NewUserTag("ben-harper"))
-	c.Assert(model.Type(), gc.Equals, "iaas")
+	c.Assert(model.Type(), gc.Equals, IAAS)
 }
 
 func (s *ModelSerializationSuite) TestVersion1IgnoresRemoteApplications(c *gc.C) {

--- a/unit.go
+++ b/unit.go
@@ -355,7 +355,7 @@ func (u *unit) Validate() error {
 	if u.WorkloadStatus_ == nil {
 		return errors.NotValidf("unit %q missing workload status", u.Name_)
 	}
-	if u.Tools_ == nil && u.Type_ != "caas" {
+	if u.Tools_ == nil && u.Type_ != CAAS {
 		return errors.NotValidf("unit %q missing tools", u.Name_)
 	}
 	return nil

--- a/unit.go
+++ b/unit.go
@@ -9,15 +9,67 @@ import (
 	"gopkg.in/juju/names.v2"
 )
 
+// Unit represents an instance of a unit in a model.
+type Unit interface {
+	HasAnnotations
+	HasConstraints
+
+	Tag() names.UnitTag
+	Name() string
+	Type() string
+	Machine() names.MachineTag
+
+	PasswordHash() string
+
+	Principal() names.UnitTag
+	Subordinates() []names.UnitTag
+
+	MeterStatusCode() string
+	MeterStatusInfo() string
+
+	Tools() AgentTools
+	SetTools(AgentToolsArgs)
+
+	WorkloadStatus() Status
+	SetWorkloadStatus(StatusArgs)
+
+	WorkloadStatusHistory() []Status
+	SetWorkloadStatusHistory([]StatusArgs)
+
+	WorkloadVersion() string
+
+	WorkloadVersionHistory() []Status
+	SetWorkloadVersionHistory([]StatusArgs)
+
+	AgentStatus() Status
+	SetAgentStatus(StatusArgs)
+
+	AgentStatusHistory() []Status
+	SetAgentStatusHistory([]StatusArgs)
+
+	AddResource(UnitResourceArgs) UnitResource
+	Resources() []UnitResource
+
+	AddPayload(PayloadArgs) Payload
+	Payloads() []Payload
+
+	CloudContainer() CloudContainer
+	SetCloudContainer(CloudContainerArgs)
+
+	Validate() error
+}
+
 type units struct {
 	Version int     `yaml:"version"`
 	Units_  []*unit `yaml:"units"`
 }
 
 type unit struct {
-	Name_ string `yaml:"name"`
-
+	Name_    string `yaml:"name"`
 	Machine_ string `yaml:"machine"`
+
+	// Type is not exported in YAML, it is set from the application type.
+	Type_ string `yaml:"-"`
 
 	AgentStatus_        *status        `yaml:"agent-status"`
 	AgentStatusHistory_ StatusHistory_ `yaml:"agent-status-history"`
@@ -32,7 +84,7 @@ type unit struct {
 	Subordinates_ []string `yaml:"subordinates,omitempty"`
 
 	PasswordHash_ string      `yaml:"password-hash"`
-	Tools_        *agentTools `yaml:"tools"`
+	Tools_        *agentTools `yaml:"tools,omitempty"`
 
 	MeterStatusCode_ string `yaml:"meter-status-code,omitempty"`
 	MeterStatusInfo_ string `yaml:"meter-status-info,omitempty"`
@@ -51,6 +103,7 @@ type unit struct {
 // UnitArgs is an argument struct used to add a Unit to a Application in the Model.
 type UnitArgs struct {
 	Tag          names.UnitTag
+	Type         string
 	Machine      names.MachineTag
 	PasswordHash string
 	Principal    names.UnitTag
@@ -72,6 +125,7 @@ func newUnit(args UnitArgs) *unit {
 	}
 	u := &unit{
 		Name_:                   args.Tag.Id(),
+		Type_:                   args.Type,
 		Machine_:                args.Machine.Id(),
 		PasswordHash_:           args.PasswordHash,
 		CloudContainer_:         newCloudContainer(args.CloudContainer),
@@ -97,6 +151,11 @@ func (u *unit) Tag() names.UnitTag {
 // Name implements Unit.
 func (u *unit) Name() string {
 	return u.Name_
+}
+
+// Type implements Unit
+func (u *unit) Type() string {
+	return u.Type_
 }
 
 // Machine implements Unit.
@@ -296,7 +355,7 @@ func (u *unit) Validate() error {
 	if u.WorkloadStatus_ == nil {
 		return errors.NotValidf("unit %q missing workload status", u.Name_)
 	}
-	if u.Tools_ == nil {
+	if u.Tools_ == nil && u.Type_ != "caas" {
 		return errors.NotValidf("unit %q missing tools", u.Name_)
 	}
 	return nil
@@ -382,6 +441,7 @@ func unitV2Fields() (schema.Fields, schema.Defaults) {
 	fields, defaults := unitV1Fields()
 	fields["cloud-container"] = schema.StringMap(schema.Any())
 	defaults["cloud-container"] = schema.Omit
+	defaults["tools"] = schema.Omit
 	return fields, defaults
 }
 
@@ -451,13 +511,18 @@ func importUnit(fields schema.Fields, defaults schema.Defaults, importVersion in
 
 	result.Subordinates_ = convertToStringSlice(valid["subordinates"])
 
-	// Tools and status are required, so we expect them to be there.
-	tools, err := importAgentTools(valid["tools"].(map[string]interface{}))
-	if err != nil {
-		return nil, errors.Trace(err)
+	// Tools are required for IAAS units but not for CAAS.
+	// Validation is done in importApplication().
+	toolsMap, ok := valid["tools"].(map[string]interface{})
+	if ok {
+		tools, err := importAgentTools(toolsMap)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		result.Tools_ = tools
 	}
-	result.Tools_ = tools
 
+	// Status is required, so we expect it to be there.
 	agentStatus, err := importStatus(valid["agent-status"].(map[string]interface{}))
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/unit_test.go
+++ b/unit_test.go
@@ -72,12 +72,12 @@ func minimalCloudContainerArgs() CloudContainerArgs {
 
 func minimalUnit(args ...UnitArgs) *unit {
 	if len(args) == 0 {
-		args = []UnitArgs{minimalUnitArgs("iaas")}
+		args = []UnitArgs{minimalUnitArgs(IAAS)}
 	}
 	u := newUnit(args[0])
 	u.SetAgentStatus(minimalStatusArgs())
 	u.SetWorkloadStatus(minimalStatusArgs())
-	if u.Type_ != "caas" {
+	if u.Type_ != CAAS {
 		u.SetTools(minimalAgentToolsArgs())
 	}
 	return u
@@ -90,7 +90,7 @@ func minimalUnitArgs(modelType string) UnitArgs {
 		Machine:      names.NewMachineTag("0"),
 		PasswordHash: "secure-hash",
 	}
-	if modelType == "caas" {
+	if modelType == CAAS {
 		result.CloudContainer = &CloudContainerArgs{
 			ProviderId: "some-provider",
 			Address:    AddressArgs{Value: "10.0.0.1", Type: "special"},
@@ -152,7 +152,7 @@ func (s *UnitSerializationSuite) TestMinimalUnitValid(c *gc.C) {
 }
 
 func (s *UnitSerializationSuite) TestMinimalCAASUnitValid(c *gc.C) {
-	unit := minimalUnit(minimalUnitArgs("caas"))
+	unit := minimalUnit(minimalUnitArgs(CAAS))
 	c.Assert(unit.Validate(), jc.ErrorIsNil)
 }
 
@@ -233,7 +233,7 @@ func (s *UnitSerializationSuite) TestConstraints(c *gc.C) {
 }
 
 func (s *UnitSerializationSuite) TestCloudContainer(c *gc.C) {
-	initial := minimalUnit(minimalUnitArgs("caas"))
+	initial := minimalUnit(minimalUnitArgs(CAAS))
 	args := CloudContainerArgs{
 		ProviderId: "some-provider",
 		Address:    AddressArgs{Value: "10.0.0.1", Type: "special"},
@@ -246,7 +246,7 @@ func (s *UnitSerializationSuite) TestCloudContainer(c *gc.C) {
 }
 
 func (s *UnitSerializationSuite) TestCAASUnitNoTools(c *gc.C) {
-	initial := minimalUnit(minimalUnitArgs("caas"))
+	initial := minimalUnit(minimalUnitArgs(CAAS))
 	unit := s.exportImportLatest(c, initial)
 	c.Assert(unit.Tools_, gc.IsNil)
 }


### PR DESCRIPTION
CAAS units do not have tools metadata so make it optional.

As a driveby, move the unit interface from interfaces.go to unit.go (the preferred place).