### PR TITLE
v2 attachment schema suppports host-id instead of machine-id

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -116,7 +116,7 @@ type Volume interface {
 
 // VolumeAttachment represents a volume attached to a machine.
 type VolumeAttachment interface {
-	Machine() names.MachineTag
+	Host() names.Tag
 	Provisioned() bool
 	ReadOnly() bool
 	DeviceName() string
@@ -158,7 +158,7 @@ type Filesystem interface {
 
 // FilesystemAttachment represents a filesystem attached to a machine.
 type FilesystemAttachment interface {
-	Machine() names.MachineTag
+	Host() names.Tag
 	Provisioned() bool
 	MountPoint() string
 	ReadOnly() bool

--- a/model.go
+++ b/model.go
@@ -906,8 +906,11 @@ func (m *model) validateStorage(allMachineIDs, allApplications, allUnits set.Str
 			return errors.NotValidf("volume[%d] referencing unknown storage %q", i, storeID)
 		}
 		for j, attachment := range volume.Attachments() {
-			if machineID := attachment.Machine().Id(); !allMachineIDs.Contains(machineID) {
-				return errors.NotValidf("volume[%d].attachment[%d] referencing unknown machine %q", i, j, machineID)
+			hostID := attachment.Host().Id()
+			knownMachine := allMachineIDs.Contains(hostID)
+			knownUnit := allUnits.Contains(hostID)
+			if !knownMachine && !knownUnit {
+				return errors.NotValidf("volume[%d].attachment[%d] referencing unknown machine or unit %q", i, j, hostID)
 			}
 		}
 	}
@@ -922,8 +925,11 @@ func (m *model) validateStorage(allMachineIDs, allApplications, allUnits set.Str
 			return errors.NotValidf("filesystem[%d] referencing unknown volume %q", i, volID)
 		}
 		for j, attachment := range filesystem.Attachments() {
-			if machineID := attachment.Machine().Id(); !allMachineIDs.Contains(machineID) {
-				return errors.NotValidf("filesystem[%d].attachment[%d] referencing unknown machine %q", i, j, machineID)
+			hostID := attachment.Host().Id()
+			knownMachine := allMachineIDs.Contains(hostID)
+			knownUnit := allUnits.Contains(hostID)
+			if !knownMachine && !knownUnit {
+				return errors.NotValidf("filesystem[%d].attachment[%d] referencing unknown machine or unit %q", i, j, hostID)
 			}
 		}
 	}


### PR DESCRIPTION
Volume and filesystem attachments now use "host-id" which is a generic tag to record the host of an attachment. This allows hosts to be more than just machines, eg units.