### PR TITLE
Fix incorrect unit attachment parsing

### DIFF
--- a/filesystem.go
+++ b/filesystem.go
@@ -278,7 +278,7 @@ func newFilesystemAttachment(args FilesystemAttachmentArgs) *filesystemAttachmen
 
 // Host implements FilesystemAttachment
 func (a *filesystemAttachment) Host() names.Tag {
-	return names.NewMachineTag(a.HostID_)
+	return storageAttachmentHost(a.HostID_)
 }
 
 // Provisioned implements FilesystemAttachment

--- a/filesystem_test.go
+++ b/filesystem_test.go
@@ -283,3 +283,17 @@ func (s *FilesystemAttachmentSerializationSuite) TestV1ParsingReturnsLatest(c *g
 		Provisioned_: true,
 	})
 }
+
+func (s *FilesystemAttachmentSerializationSuite) TestUnitAttachmentParsing(c *gc.C) {
+	attachmentMap := testFilesystemAttachmentMap()
+	attachmentMap["host-id"] = "gitlab/0"
+
+	attachment, err := importFilesystemAttachmentV2(attachmentMap)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(attachment, jc.DeepEquals, &filesystemAttachment{
+		HostID_:      "gitlab/0",
+		MountPoint_:  "/some/dir",
+		ReadOnly_:    true,
+		Provisioned_: true,
+	})
+}

--- a/volume.go
+++ b/volume.go
@@ -425,9 +425,16 @@ func newVolumeAttachment(args VolumeAttachmentArgs) *volumeAttachment {
 	}
 }
 
+func storageAttachmentHost(id string) names.Tag {
+	if names.IsValidUnit(id) {
+		return names.NewUnitTag(id)
+	}
+	return names.NewMachineTag(id)
+}
+
 // Host implements VolumeAttachment
 func (a *volumeAttachment) Host() names.Tag {
-	return names.NewMachineTag(a.HostID_)
+	return storageAttachmentHost(a.HostID_)
 }
 
 // Provisioned implements VolumeAttachment

--- a/volume_test.go
+++ b/volume_test.go
@@ -332,3 +332,19 @@ func (s *VolumeAttachmentSerializationSuite) TestV1ParsingReturnsLatest(c *gc.C)
 		BusAddress_:  "nfi",
 	})
 }
+
+func (s *VolumeAttachmentSerializationSuite) TestUnitAttachmentParsing(c *gc.C) {
+	attachmentMap := testVolumeAttachmentMap()
+	attachmentMap["host-id"] = "gitlab/0"
+
+	attachment, err := importVolumeAttachmentV2(attachmentMap)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(attachment, jc.DeepEquals, &volumeAttachment{
+		HostID_:      "gitlab/0",
+		ReadOnly_:    true,
+		Provisioned_: true,
+		DeviceName_:  "sdd",
+		DeviceLink_:  "link?",
+		BusAddress_:  "nfi",
+	})
+}


### PR DESCRIPTION
Unit attachments were incorrectly being interpreted as machine tags.
Fix the issue and add tests.