### PR TITLE
Addition of operator-status and neverset

### DIFF
--- a/application_test.go
+++ b/application_test.go
@@ -90,6 +90,7 @@ func minimalApplicationMapCAAS() map[interface{}]interface{} {
 		},
 	}
 	result["tools"] = minimalAgentToolsMap()
+	result["operator-status"] = minimalStatusMap()
 	return result
 }
 
@@ -105,6 +106,7 @@ func minimalApplication(args ...ApplicationArgs) *application {
 	a.setResources([]*resource{minimalResource()})
 	if a.Type_ == CAAS {
 		a.SetTools(minimalAgentToolsArgs())
+		a.SetOperatorStatus(minimalStatusArgs())
 	} else {
 		u.SetTools(minimalAgentToolsArgs())
 	}
@@ -293,6 +295,7 @@ func (s *ApplicationSerializationSuite) TestV2ParsingReturnsLatest(c *gc.C) {
 	appLatest.DesiredScale_ = 0
 	appLatest.CloudService_ = nil
 	appLatest.Tools_ = nil
+	appLatest.OperatorStatus_ = nil
 
 	appResult := s.exportImportVersion(c, appV1, 2)
 	c.Assert(appResult, jc.DeepEquals, appLatest)
@@ -306,6 +309,7 @@ func (s *ApplicationSerializationSuite) TestV3ParsingReturnsLatest(c *gc.C) {
 	appLatest := appV2
 	appLatest.Placement_ = ""
 	appLatest.DesiredScale_ = 0
+	appLatest.OperatorStatus_ = nil
 
 	appResult := s.exportImportVersion(c, appV2, 3)
 	c.Assert(appResult, jc.DeepEquals, appLatest)

--- a/model_test.go
+++ b/model_test.go
@@ -796,9 +796,10 @@ remote-applications:
     version: 1
   status:
     status:
+      neverset: false
       updated: 2017-05-09T12:01:00Z
       value: running
-    version: 1
+    version: 2
   url: other.mysql
 version: 1
 `[1:]

--- a/remoteapplication_test.go
+++ b/remoteapplication_test.go
@@ -38,14 +38,15 @@ func minimalRemoteApplicationMap() map[interface{}]interface{} {
 		"source-model-uuid": "abcd-1234",
 		"is-consumer-proxy": true,
 		"status": map[interface{}]interface{}{
-			"version": 1,
+			"version": 2,
 			"status": map[interface{}]interface{}{
 				"value":   "running",
 				"message": "monkey & bear",
 				"data": map[interface{}]interface{}{
 					"after": "the curtain",
 				},
-				"updated": "2016-01-28T11:50:00Z",
+				"updated":  "2016-01-28T11:50:00Z",
+				"neverset": false,
 			},
 		},
 		"endpoints": map[interface{}]interface{}{


### PR DESCRIPTION
Add operator-status for CAAS model migrations.
Add neverset field for status so that applications that derive status from
units continue showing the correct status after migration.