### PR TITLE
Modification Status on CloudInstance

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -600,6 +600,7 @@ func importMachineV1(source map[string]interface{}) (*machine, error) {
 type CloudInstance interface {
 	HasStatus
 	HasStatusHistory
+	HasModificationStatus
 
 	InstanceId() string
 	Architecture() string
@@ -634,7 +635,7 @@ func newCloudInstance(args CloudInstanceArgs) *cloudInstance {
 	profiles := make([]string, len(args.CharmProfiles))
 	copy(profiles, args.CharmProfiles)
 	return &cloudInstance{
-		Version:           3,
+		Version:           4,
 		InstanceId_:       args.InstanceId,
 		Architecture_:     args.Architecture,
 		Memory_:           args.Memory,
@@ -653,8 +654,9 @@ type cloudInstance struct {
 
 	InstanceId_ string `yaml:"instance-id"`
 
-	Status_        *status `yaml:"status"`
-	StatusHistory_ `yaml:"status-history"`
+	Status_             *status `yaml:"status"`
+	StatusHistory_      `yaml:"status-history"`
+	ModificationStatus_ *status `yaml:"modification-status,omitempty"`
 
 	// For all the optional values, empty values make no sense, and
 	// it would be better to have them not set rather than set with
@@ -686,6 +688,20 @@ func (c *cloudInstance) Status() Status {
 // SetStatus implements CloudInstance.
 func (c *cloudInstance) SetStatus(args StatusArgs) {
 	c.Status_ = newStatus(args)
+}
+
+// ModificationStatus implements CloudInstance.
+func (c *cloudInstance) ModificationStatus() Status {
+	// To avoid typed nils check nil here.
+	if c.ModificationStatus_ == nil {
+		return nil
+	}
+	return c.ModificationStatus_
+}
+
+// SetModificationStatus implements CloudInstance.
+func (c *cloudInstance) SetModificationStatus(args StatusArgs) {
+	c.ModificationStatus_ = newStatus(args)
 }
 
 // Architecture implements CloudInstance.
@@ -763,6 +779,7 @@ var cloudInstanceDeserializationFuncs = map[int]cloudInstanceDeserializationFunc
 	1: importCloudInstanceV1,
 	2: importCloudInstanceV2,
 	3: importCloudInstanceV3,
+	4: importCloudInstanceV4,
 }
 
 func cloudInstanceV1Fields() (schema.Fields, schema.Defaults) {
@@ -804,6 +821,13 @@ func cloudInstanceV3Fields() (schema.Fields, schema.Defaults) {
 	return fields, defaults
 }
 
+func cloudInstanceV4Fields() (schema.Fields, schema.Defaults) {
+	fields, defaults := cloudInstanceV3Fields()
+	fields["modification-status"] = schema.StringMap(schema.Any())
+	defaults["modification-status"] = schema.Omit
+	return fields, defaults
+}
+
 func importCloudInstanceV1(source map[string]interface{}) (*cloudInstance, error) {
 	return importCloudInstanceVx(source, 1, cloudInstanceV1Fields)
 }
@@ -814,6 +838,10 @@ func importCloudInstanceV2(source map[string]interface{}) (*cloudInstance, error
 
 func importCloudInstanceV3(source map[string]interface{}) (*cloudInstance, error) {
 	return importCloudInstanceVx(source, 3, cloudInstanceV3Fields)
+}
+
+func importCloudInstanceV4(source map[string]interface{}) (*cloudInstance, error) {
+	return importCloudInstanceVx(source, 4, cloudInstanceV4Fields)
 }
 
 func importCloudInstanceVx(source map[string]interface{}, version int, fieldFunc func() (schema.Fields, schema.Defaults)) (*cloudInstance, error) {
@@ -832,7 +860,7 @@ func importCloudInstanceVx(source map[string]interface{}, version int, fieldFunc
 
 func newCloudInstanceFromValid(valid map[string]interface{}, importVersion int) (*cloudInstance, error) {
 	instance := &cloudInstance{
-		Version:           3,
+		Version:           4,
 		InstanceId_:       valid["instance-id"].(string),
 		Architecture_:     valid["architecture"].(string),
 		Memory_:           valid["memory"].(uint64),
@@ -862,6 +890,13 @@ func newCloudInstanceFromValid(valid map[string]interface{}, importVersion int) 
 			return nil, errors.Trace(err)
 		}
 
+		if importVersion > 3 {
+			modificationStatus, err := importModificationStatus(valid["modification-status"])
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			instance.ModificationStatus_ = modificationStatus
+		}
 	default:
 		return nil, errors.NotValidf("unexpected version: %d", importVersion)
 	}

--- a/machine.go
+++ b/machine.go
@@ -654,8 +654,14 @@ type cloudInstance struct {
 
 	InstanceId_ string `yaml:"instance-id"`
 
-	Status_             *status `yaml:"status"`
-	StatusHistory_      `yaml:"status-history"`
+	Status_        *status `yaml:"status"`
+	StatusHistory_ `yaml:"status-history"`
+
+	// ModificationStatus_ defines a status that can be used to highlight status
+	// changes to a machine instance after it's been provisioned. This is
+	// different from agent-status or machine-status, where the statuses tend to
+	// imply how the machine health is during a provisioning cycle or hook
+	// integration.
 	ModificationStatus_ *status `yaml:"modification-status,omitempty"`
 
 	// For all the optional values, empty values make no sense, and

--- a/machine_test.go
+++ b/machine_test.go
@@ -278,6 +278,10 @@ func (*MachineSerializationSuite) TestNestedParsing(c *gc.C) {
 	c.Assert(machines, jc.DeepEquals, expected)
 }
 
+// TestNestedParsingWithPriorVersion tests the scenario of a using a version of
+// a machine with a older version of a cloud instance. We want to ensure that
+// we can mix and match type versions without inducing a panic that was found
+// whilst developing.
 func (*MachineSerializationSuite) TestNestedParsingWithPriorVersion(c *gc.C) {
 	machines, err := importMachines(map[string]interface{}{
 		"version": 1,

--- a/model_test.go
+++ b/model_test.go
@@ -152,6 +152,18 @@ func (s *ModelSerializationSuite) TestVersions(c *gc.C) {
 }
 
 func (s *ModelSerializationSuite) TestParsingYAML(c *gc.C) {
+	s.testParsingYAMLWithMachine(c, func(initial Model) {
+		addMinimalMachine(initial, "0")
+	})
+}
+
+func (s *ModelSerializationSuite) TestParsingYAMLWithMissingModificationStatus(c *gc.C) {
+	s.testParsingYAMLWithMachine(c, func(initial Model) {
+		addMinimalMachineWithMissingModificationStatus(initial, "0")
+	})
+}
+
+func (s *ModelSerializationSuite) testParsingYAMLWithMachine(c *gc.C, machineFn func(Model)) {
 	args := ModelArgs{
 		Type:  IAAS,
 		Owner: names.NewUserTag("magic"),
@@ -180,7 +192,7 @@ func (s *ModelSerializationSuite) TestParsingYAML(c *gc.C) {
 		DateCreated: time.Date(2015, 10, 9, 12, 34, 56, 0, time.UTC),
 	})
 	initial.SetStatus(StatusArgs{Value: "available"})
-	addMinimalMachine(initial, "0")
+	machineFn(initial)
 	addMinimalApplication(initial)
 	model := s.exportImport(c, initial)
 
@@ -302,6 +314,7 @@ func (s *ModelSerializationSuite) addMachineToModel(model Model, id string) Mach
 	machine.SetTools(minimalAgentToolsArgs())
 	machine.SetStatus(minimalStatusArgs())
 	machine.Instance().SetStatus(minimalStatusArgs())
+	machine.Instance().SetModificationStatus(minimalStatusArgs())
 	return machine
 }
 

--- a/status.go
+++ b/status.go
@@ -22,6 +22,13 @@ type HasOperatorStatus interface {
 	OperatorStatus() Status
 }
 
+// HasModificationStatus defines the comment methods for setting and getting
+// status entries for the various entities that are modified by actions.
+type HasModificationStatus interface {
+	ModificationStatus() Status
+	SetModificationStatus(StatusArgs)
+}
+
 // HasStatusHistory defines the common methods for setting and
 // getting historical status entries for the various entities.
 type HasStatusHistory interface {
@@ -176,6 +183,13 @@ func importStatusList(sourceList []interface{}, getFields statusFieldsFunc, vers
 		result = append(result, &point)
 	}
 	return result, nil
+}
+
+func importModificationStatus(source interface{}) (*status, error) {
+	if sourceMap, ok := source.(map[string]interface{}); ok {
+		return importStatus(sourceMap)
+	}
+	return nil, nil
 }
 
 type statusFieldsFunc func() (schema.Fields, schema.Defaults)

--- a/status.go
+++ b/status.go
@@ -24,8 +24,17 @@ type HasOperatorStatus interface {
 
 // HasModificationStatus defines the comment methods for setting and getting
 // status entries for the various entities that are modified by actions.
+// The modification changes, are changes that can alter the machine instance
+// and setting the status can then be surfaced to the operator using the status.
+// This is different from agent-status or machine-status, where the statuses
+// tend to imply how the machine health is during a provisioning cycle or hook
+// integration.
+// Statuses that are expected: Applied, Error.
 type HasModificationStatus interface {
 	ModificationStatus() Status
+	// SetModificationStatus allows the changing of the modification status, of
+	// a type, which is meant to highlight the changing to a machine instance
+	// after it's been provisioned.
 	SetModificationStatus(StatusArgs)
 }
 


### PR DESCRIPTION
The following commit bumps the CloudInstance to V4 by adding a
modification status to the interface. The modification-status
defines a way to highlight status changes to the operator of
modifications to a machine whilst it's running. This differs from
status and agent-status, which are generally defined as a way to
know about changes during provisioning.