### PR TITLE
Add support for application offers

### DIFF
--- a/application_test.go
+++ b/application_test.go
@@ -65,6 +65,12 @@ func minimalApplicationMap() map[interface{}]interface{} {
 				minimalUnitMap(),
 			},
 		},
+		"offers": map[interface{}]interface{}{
+			"version": 1,
+			"offers": []interface{}{
+				minimalApplicationOfferMap(),
+			},
+		},
 	}
 }
 
@@ -91,6 +97,7 @@ func minimalApplicationMapCAAS() map[interface{}]interface{} {
 	}
 	result["tools"] = minimalAgentToolsMap()
 	result["operator-status"] = minimalStatusMap()
+	delete(result, "offers")
 	return result
 }
 
@@ -109,6 +116,12 @@ func minimalApplication(args ...ApplicationArgs) *application {
 		a.SetOperatorStatus(minimalStatusArgs())
 	} else {
 		u.SetTools(minimalAgentToolsArgs())
+		a.setOffers([]*applicationOffer{
+			{
+				OfferName_: "my-offer",
+				Endpoints_: []string{"endpoint-1", "endpoint-2"},
+			},
+		})
 	}
 	return a
 }
@@ -262,7 +275,7 @@ func (s *ApplicationSerializationSuite) exportImportVersion(c *gc.C, application
 }
 
 func (s *ApplicationSerializationSuite) exportImportLatest(c *gc.C, application_ *application) *application {
-	return s.exportImportVersion(c, application_, 4)
+	return s.exportImportVersion(c, application_, 5)
 }
 
 func (s *ApplicationSerializationSuite) TestV1ParsingReturnsLatest(c *gc.C) {
@@ -279,6 +292,7 @@ func (s *ApplicationSerializationSuite) TestV1ParsingReturnsLatest(c *gc.C) {
 	appLatest.CloudService_ = nil
 	appLatest.Tools_ = nil
 	appLatest.OperatorStatus_ = nil
+	appLatest.Offers_ = nil
 
 	appResult := s.exportImportVersion(c, appV1, 1)
 	c.Assert(appResult, jc.DeepEquals, appLatest)
@@ -297,6 +311,7 @@ func (s *ApplicationSerializationSuite) TestV2ParsingReturnsLatest(c *gc.C) {
 	appLatest.CloudService_ = nil
 	appLatest.Tools_ = nil
 	appLatest.OperatorStatus_ = nil
+	appLatest.Offers_ = nil
 
 	appResult := s.exportImportVersion(c, appV1, 2)
 	c.Assert(appResult, jc.DeepEquals, appLatest)
@@ -311,6 +326,7 @@ func (s *ApplicationSerializationSuite) TestV3ParsingReturnsLatest(c *gc.C) {
 	appLatest.Placement_ = ""
 	appLatest.DesiredScale_ = 0
 	appLatest.OperatorStatus_ = nil
+	appLatest.Offers_ = nil
 
 	appResult := s.exportImportVersion(c, appV2, 3)
 	c.Assert(appResult, jc.DeepEquals, appLatest)

--- a/applicationoffer.go
+++ b/applicationoffer.go
@@ -3,6 +3,11 @@
 
 package description
 
+import (
+	"github.com/juju/errors"
+	"github.com/juju/schema"
+)
+
 // ApplicationOffer represents an offer for a an application's endpoints.
 type ApplicationOffer interface {
 	OfferName() string
@@ -10,6 +15,11 @@ type ApplicationOffer interface {
 }
 
 var _ ApplicationOffer = (*applicationOffer)(nil)
+
+type applicationOffers struct {
+	Version int                 `yaml:"version"`
+	Offers  []*applicationOffer `yaml:"offers"`
+}
 
 type applicationOffer struct {
 	OfferName_ string   `yaml:"offer-name"`
@@ -36,4 +46,71 @@ func newApplicationOffer(args ApplicationOfferArgs) *applicationOffer {
 		OfferName_: args.OfferName,
 		Endpoints_: args.Endpoints,
 	}
+}
+
+func importApplicationOffers(source map[string]interface{}) ([]*applicationOffer, error) {
+	checker := versionedChecker("offers")
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "offers version schema check failed")
+	}
+	valid := coerced.(map[string]interface{})
+
+	version := int(valid["version"].(int64))
+	importFunc, ok := applicationOfferDeserializationFuncs[version]
+	if !ok {
+		return nil, errors.NotValidf("version %d", version)
+	}
+
+	sourceList := valid["offers"].([]interface{})
+	return importApplicationOfferList(sourceList, importFunc)
+}
+
+func importApplicationOfferList(sourceList []interface{}, importFunc applicationOfferDeserializationFunc) ([]*applicationOffer, error) {
+	result := make([]*applicationOffer, 0, len(sourceList))
+
+	for i, value := range sourceList {
+		source, ok := value.(map[string]interface{})
+		if !ok {
+			return nil, errors.Errorf("unexpected value for application offer %d, %T", i, value)
+		}
+
+		offer, err := importFunc(source)
+		if err != nil {
+			return nil, errors.Annotatef(err, "application offer %d", i)
+		}
+		result = append(result, offer)
+	}
+	return result, nil
+}
+
+type applicationOfferDeserializationFunc func(interface{}) (*applicationOffer, error)
+
+var applicationOfferDeserializationFuncs = map[int]applicationOfferDeserializationFunc{
+	1: importApplicationOfferV1,
+}
+
+func importApplicationOfferV1(source interface{}) (*applicationOffer, error) {
+	fields := schema.Fields{
+		"offer-name": schema.String(),
+		"endpoints":  schema.List(schema.String()),
+	}
+	checker := schema.FieldMap(fields, nil)
+
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "application offer v1 schema check failed")
+	}
+	valid := coerced.(map[string]interface{})
+
+	validEndpoints := valid["endpoints"].([]interface{})
+	endpoints := make([]string, len(validEndpoints))
+	for i, ep := range validEndpoints {
+		endpoints[i] = ep.(string)
+	}
+
+	return &applicationOffer{
+		OfferName_: valid["offer-name"].(string),
+		Endpoints_: endpoints,
+	}, nil
 }

--- a/applicationoffer.go
+++ b/applicationoffer.go
@@ -1,0 +1,39 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package description
+
+// ApplicationOffer represents an offer for a an application's endpoints.
+type ApplicationOffer interface {
+	OfferName() string
+	Endpoints() []string
+}
+
+var _ ApplicationOffer = (*applicationOffer)(nil)
+
+type applicationOffer struct {
+	OfferName_ string   `yaml:"offer-name"`
+	Endpoints_ []string `yaml:"endpoints"`
+}
+
+func (o *applicationOffer) OfferName() string {
+	return o.OfferName_
+}
+
+func (o *applicationOffer) Endpoints() []string {
+	return o.Endpoints_
+}
+
+// ApplicationOfferArgs is an argument struct used to instanciate a new
+// applicationOffer instance that implements ApplicationOffer.
+type ApplicationOfferArgs struct {
+	OfferName string
+	Endpoints []string
+}
+
+func newApplicationOffer(args ApplicationOfferArgs) *applicationOffer {
+	return &applicationOffer{
+		OfferName_: args.OfferName,
+		Endpoints_: args.Endpoints,
+	}
+}

--- a/applicationoffer_test.go
+++ b/applicationoffer_test.go
@@ -1,0 +1,23 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package description
+
+import (
+	gc "gopkg.in/check.v1"
+)
+
+type ApplicationOfferSerializationSuite struct {
+}
+
+var _ = gc.Suite(&ApplicationOfferSerializationSuite{})
+
+func (s *ApplicationOfferSerializationSuite) TestNewApplicationOffer(c *gc.C) {
+	offer := newApplicationOffer(ApplicationOfferArgs{
+		OfferName: "my-offer",
+		Endpoints: []string{"endpoint-1", "endpoint-2"},
+	})
+
+	c.Check(offer.OfferName(), gc.Equals, "my-offer")
+	c.Check(offer.Endpoints(), gc.DeepEquals, []string{"endpoint-1", "endpoint-2"})
+}

--- a/model.go
+++ b/model.go
@@ -398,7 +398,7 @@ func (m *model) AddApplication(args ApplicationArgs) Application {
 
 func (m *model) setApplications(applicationList []*application) {
 	m.Applications_ = applications{
-		Version:       4,
+		Version:       5,
 		Applications_: applicationList,
 	}
 }


### PR DESCRIPTION
This PR introduces the `ApplicationOffer` interface (not to be confused with the `RemoteApplication` type) and its concrete implementation `applicationOffer`.

The `Application` interface has been extended with additional methods for adding new offers and retrieving the list of offers associated with an application instance.

To make sure the introduced changes do not break backwards compatibility, the offer list is only exposed in v5 application payloads (bumped from the previous value, v4)

This PR is part of the work required for including offers in `juju export-bundle` output.