### PR TITLE
Expose an ACL for each offer

### DIFF
--- a/application_test.go
+++ b/application_test.go
@@ -131,6 +131,11 @@ func minimalApplicationWithOffer(args ...ApplicationArgs) *application {
 			{
 				OfferName_: "my-offer",
 				Endpoints_: []string{"endpoint-1", "endpoint-2"},
+				ACL_: map[string]string{
+					"admin": "admin",
+					"foo":   "read",
+					"bar":   "consume",
+				},
 			},
 		})
 	}

--- a/applicationoffer_test.go
+++ b/applicationoffer_test.go
@@ -31,16 +31,31 @@ func (s *ApplicationOfferSerializationSuite) TestNewApplicationOffer(c *gc.C) {
 	offer := newApplicationOffer(ApplicationOfferArgs{
 		OfferName: "my-offer",
 		Endpoints: []string{"endpoint-1", "endpoint-2"},
+		ACL: map[string]string{
+			"admin": "admin",
+			"foo":   "read",
+			"bar":   "consume",
+		},
 	})
 
 	c.Check(offer.OfferName(), gc.Equals, "my-offer")
 	c.Check(offer.Endpoints(), gc.DeepEquals, []string{"endpoint-1", "endpoint-2"})
+	c.Check(offer.ACL(), gc.DeepEquals, map[string]string{
+		"admin": "admin",
+		"foo":   "read",
+		"bar":   "consume",
+	})
 }
 
 func (s *ApplicationOfferSerializationSuite) TestParsingSerializedData(c *gc.C) {
 	initial := newApplicationOffer(ApplicationOfferArgs{
 		OfferName: "my-offer",
 		Endpoints: []string{"endpoint-1", "endpoint-2"},
+		ACL: map[string]string{
+			"admin": "admin",
+			"foo":   "read",
+			"bar":   "consume",
+		},
 	})
 	offer := s.exportImportLatest(c, initial)
 	c.Assert(offer, jc.DeepEquals, initial)
@@ -73,5 +88,10 @@ func minimalApplicationOfferMap() map[interface{}]interface{} {
 	return map[interface{}]interface{}{
 		"offer-name": "my-offer",
 		"endpoints":  []interface{}{"endpoint-1", "endpoint-2"},
+		"acl": map[interface{}]interface{}{
+			"admin": "admin",
+			"foo":   "read",
+			"bar":   "consume",
+		},
 	}
 }


### PR DESCRIPTION
This PR builds on top of the work from #52 and adds exposes an ACL for each offer. The ACL is a map where the keys are users and the values are access permissions.