### PR TITLE
Revert #54 and Allow nil Device Attributes in Volume Attachement Plans

### DIFF
--- a/volume.go
+++ b/volume.go
@@ -634,7 +634,11 @@ func importVolumePlanInfo(source map[string]interface{}) (volumePlanInfo, error)
 		"device-attributes": schema.StringMap(schema.String()),
 	}
 
-	checker := schema.FieldMap(fields, nil)
+	defaults := schema.Defaults{
+		"device-attributes": schema.Omit,
+	}
+
+	checker := schema.FieldMap(fields, defaults)
 
 	coerced, err := checker.Coerce(source, nil)
 	if err != nil {
@@ -642,11 +646,14 @@ func importVolumePlanInfo(source map[string]interface{}) (volumePlanInfo, error)
 	}
 	valid := coerced.(map[string]interface{})
 
-	devAttrs := coerceMapInterfacerToMapString(valid["device-attributes"].(map[string]interface{}))
-	return volumePlanInfo{
-		DeviceType_:       valid["device-type"].(string),
-		DeviceAttributes_: devAttrs,
-	}, nil
+	planInfo := volumePlanInfo{
+		DeviceType_: valid["device-type"].(string),
+	}
+	if valid["device-attributes"] != nil {
+		planInfo.DeviceAttributes_ = coerceMapInterfacerToMapString(valid["device-attributes"].(map[string]interface{}))
+	}
+
+	return planInfo, nil
 }
 
 func importVolumeAttachmentPlanV1(source map[string]interface{}) (*volumeAttachmentPlan, error) {

--- a/volume.go
+++ b/volume.go
@@ -56,19 +56,19 @@ func (v volumePlanInfo) DeviceAttributes() map[string]string {
 }
 
 type volumeAttachment struct {
-	HostID_         string          `yaml:"host-id"`
-	Provisioned_    bool            `yaml:"provisioned"`
-	ReadOnly_       bool            `yaml:"read-only"`
-	DeviceName_     string          `yaml:"device-name"`
-	DeviceLink_     string          `yaml:"device-link"`
-	BusAddress_     string          `yaml:"bus-address"`
-	VolumePlanInfo_ *volumePlanInfo `yaml:"plan-info,omitempty"`
+	HostID_         string         `yaml:"host-id"`
+	Provisioned_    bool           `yaml:"provisioned"`
+	ReadOnly_       bool           `yaml:"read-only"`
+	DeviceName_     string         `yaml:"device-name"`
+	DeviceLink_     string         `yaml:"device-link"`
+	BusAddress_     string         `yaml:"bus-address"`
+	VolumePlanInfo_ volumePlanInfo `yaml:"plan-info,omitempty"`
 }
 
 type volumeAttachmentPlan struct {
-	MachineID_   string          `yaml:"machine-id"`
-	BlockDevice_ *blockdevice    `yaml:"block-device,omitempty"`
-	PlanInfo_    *volumePlanInfo `yaml:"plan-info,omitempty"`
+	MachineID_   string         `yaml:"machine-id"`
+	BlockDevice_ *blockdevice   `yaml:"block-device,omitempty"`
+	PlanInfo_    volumePlanInfo `yaml:"plan-info,omitempty"`
 }
 
 func (v volumeAttachmentPlan) Machine() names.MachineTag {
@@ -397,39 +397,32 @@ func newVolumeAttachmentPlan(args VolumeAttachmentPlanArgs) *volumeAttachmentPla
 		InUse_:          args.InUse,
 		MountPoint_:     args.MountPoint,
 	}
-	plan := volumeAttachmentPlan{
+	planInfo := volumePlanInfo{
+		DeviceType_:       args.DeviceType,
+		DeviceAttributes_: args.DeviceAttributes,
+	}
+	return &volumeAttachmentPlan{
 		MachineID_:   args.Machine.Id(),
 		BlockDevice_: blockDevice,
+		PlanInfo_:    planInfo,
 	}
-
-	if args.DeviceType != "" && args.DeviceAttributes != nil {
-		plan.PlanInfo_ = &volumePlanInfo{
-			DeviceType_:       args.DeviceType,
-			DeviceAttributes_: args.DeviceAttributes,
-		}
-	}
-
-	return &plan
 }
 
 func newVolumeAttachment(args VolumeAttachmentArgs) *volumeAttachment {
-	att := volumeAttachment{
-		HostID_:      args.Host.Id(),
-		Provisioned_: args.Provisioned,
-		ReadOnly_:    args.ReadOnly,
-		DeviceName_:  args.DeviceName,
-		DeviceLink_:  args.DeviceLink,
-		BusAddress_:  args.BusAddress,
-	}
-
+	planInfo := volumePlanInfo{}
 	if args.DeviceType != "" && args.DeviceAttributes != nil {
-		att.VolumePlanInfo_ = &volumePlanInfo{
-			DeviceType_:       args.DeviceType,
-			DeviceAttributes_: args.DeviceAttributes,
-		}
+		planInfo.DeviceType_ = args.DeviceType
+		planInfo.DeviceAttributes_ = args.DeviceAttributes
 	}
-
-	return &att
+	return &volumeAttachment{
+		HostID_:         args.Host.Id(),
+		Provisioned_:    args.Provisioned,
+		ReadOnly_:       args.ReadOnly,
+		DeviceName_:     args.DeviceName,
+		DeviceLink_:     args.DeviceLink,
+		BusAddress_:     args.BusAddress,
+		VolumePlanInfo_: planInfo,
+	}
 }
 
 func storageAttachmentHost(id string) names.Tag {
@@ -559,20 +552,22 @@ func importVolumeAttachment(fields schema.Fields, defaults schema.Defaults, impo
 	// From here we know that the map returned from the schema coercion
 	// contains fields of the right type.
 
-	result := &volumeAttachment{
-		Provisioned_: valid["provisioned"].(bool),
-		ReadOnly_:    valid["read-only"].(bool),
-		DeviceName_:  valid["device-name"].(string),
-		DeviceLink_:  valid["device-link"].(string),
-		BusAddress_:  valid["bus-address"].(string),
-	}
+	var planInfo volumePlanInfo
 
 	if valid["plan-info"] != nil {
-		planInfo, err := importVolumePlanInfo(valid["plan-info"].(map[string]interface{}))
+		planInfo, err = importVolumePlanInfo(valid["plan-info"].(map[string]interface{}))
 		if err != nil {
 			return nil, errors.Annotatef(err, "volumeAttachmentPlanInfo schema check failed")
 		}
-		result.VolumePlanInfo_ = planInfo
+	}
+
+	result := &volumeAttachment{
+		Provisioned_:    valid["provisioned"].(bool),
+		ReadOnly_:       valid["read-only"].(bool),
+		DeviceName_:     valid["device-name"].(string),
+		DeviceLink_:     valid["device-link"].(string),
+		BusAddress_:     valid["bus-address"].(string),
+		VolumePlanInfo_: planInfo,
 	}
 
 	if importVersion >= 2 {
@@ -633,7 +628,7 @@ func coerceMapInterfacerToMapString(value map[string]interface{}) map[string]str
 	return newMap
 }
 
-func importVolumePlanInfo(source map[string]interface{}) (*volumePlanInfo, error) {
+func importVolumePlanInfo(source map[string]interface{}) (volumePlanInfo, error) {
 	fields := schema.Fields{
 		"device-type":       schema.String(),
 		"device-attributes": schema.StringMap(schema.String()),
@@ -643,12 +638,12 @@ func importVolumePlanInfo(source map[string]interface{}) (*volumePlanInfo, error
 
 	coerced, err := checker.Coerce(source, nil)
 	if err != nil {
-		return nil, errors.Annotatef(err, "volumePlanInfo schema check failed")
+		return volumePlanInfo{}, errors.Annotatef(err, "volumePlanInfo schema check failed")
 	}
 	valid := coerced.(map[string]interface{})
 
 	devAttrs := coerceMapInterfacerToMapString(valid["device-attributes"].(map[string]interface{}))
-	return &volumePlanInfo{
+	return volumePlanInfo{
 		DeviceType_:       valid["device-type"].(string),
 		DeviceAttributes_: devAttrs,
 	}, nil

--- a/volume_test.go
+++ b/volume_test.go
@@ -202,7 +202,12 @@ func testAttachmentPlanArgs(id string) VolumeAttachmentPlanArgs {
 func (s *VolumeSerializationSuite) TestAddingAttachmentPlans(c *gc.C) {
 	original := testVolume()
 	attachmentPlan1 := original.AddAttachmentPlan(testAttachmentPlanArgs("1"))
-	attachmentPlan2 := original.AddAttachmentPlan(testAttachmentPlanArgs("2"))
+
+	// Test a plan with no attributes.
+	plan := testAttachmentPlanArgs("2")
+	plan.DeviceAttributes = nil
+	attachmentPlan2 := original.AddAttachmentPlan(plan)
+
 	volume := s.exportImport(c, original)
 	c.Assert(volume, jc.DeepEquals, original)
 	attachmentPlans := volume.AttachmentPlans()

--- a/volume_test.go
+++ b/volume_test.go
@@ -94,7 +94,6 @@ func (s *VolumeSerializationSuite) TestNewVolume(c *gc.C) {
 	c.Check(volume.Persistent(), jc.IsTrue)
 
 	c.Check(volume.Attachments(), gc.HasLen, 0)
-	c.Check(volume.AttachmentPlans(), gc.HasLen, 0)
 }
 
 func (s *VolumeSerializationSuite) TestVolumeValid(c *gc.C) {
@@ -276,7 +275,6 @@ func (s *VolumeAttachmentSerializationSuite) TestNewVolumeAttachment(c *gc.C) {
 	c.Check(attachment.DeviceName(), gc.Equals, "sdd")
 	c.Check(attachment.DeviceLink(), gc.Equals, "link?")
 	c.Check(attachment.BusAddress(), gc.Equals, "nfi")
-	c.Check(attachment.VolumePlanInfo(), gc.IsNil)
 }
 
 func (s *VolumeAttachmentSerializationSuite) TestVolumeAttachmentMatches(c *gc.C) {


### PR DESCRIPTION
The previous patch (#54) was made under false assumptions. Using nil references instead of zero-value structs introduced issues in Juju with testing interface types with nil.

This patch reverts the change made under #54 and instead simply allows the `device-attributes` to be nil in `VolumeAttachmentPlan`s.

First commit is the reversion, second is the net change.