### PR TITLE
Adds new space serialisation for V2, supporting space ID

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -21,6 +21,7 @@ type AgentTools interface {
 
 // Space represents a network space, which is a named collection of subnets.
 type Space interface {
+	Id() string
 	Name() string
 	Public() bool
 	ProviderID() string

--- a/model.go
+++ b/model.go
@@ -444,7 +444,7 @@ func (m *model) AddSpace(args SpaceArgs) Space {
 
 func (m *model) setSpaces(spaceList []*space) {
 	m.Spaces_ = spaces{
-		Version: 1,
+		Version: 2,
 		Spaces_: spaceList,
 	}
 }

--- a/model_test.go
+++ b/model_test.go
@@ -965,8 +965,10 @@ func (s *ModelSerializationSuite) TestVersion1IgnoresRemoteApplications(c *gc.C)
 
 func (s *ModelSerializationSuite) TestSpaces(c *gc.C) {
 	initial := s.newModel(ModelArgs{Owner: names.NewUserTag("owner")})
-	space := initial.AddSpace(SpaceArgs{Name: "special"})
+	space := initial.AddSpace(SpaceArgs{Id: "1", Name: "special"})
 	c.Assert(space.Name(), gc.Equals, "special")
+	c.Assert(space.Id(), gc.Equals, "1")
+
 	spaces := initial.Spaces()
 	c.Assert(spaces, gc.HasLen, 1)
 	c.Assert(spaces[0], gc.Equals, space)

--- a/space_test.go
+++ b/space_test.go
@@ -34,16 +34,44 @@ func (s *SpaceSerializationSuite) TestNewSpace(c *gc.C) {
 		ProviderID: "magic",
 	}
 	space := newSpace(args)
+	c.Assert(space.Id(), gc.Equals, "")
 	c.Assert(space.Name(), gc.Equals, args.Name)
 	c.Assert(space.Public(), gc.Equals, args.Public)
 	c.Assert(space.ProviderID(), gc.Equals, args.ProviderID)
 }
 
-func (s *SpaceSerializationSuite) TestParsingSerializedData(c *gc.C) {
+func (s *SpaceSerializationSuite) TestParsingSerializedDataV1(c *gc.C) {
 	initial := spaces{
 		Version: 1,
 		Spaces_: []*space{
 			newSpace(SpaceArgs{
+				Name:       "special",
+				Public:     true,
+				ProviderID: "magic",
+			}),
+			newSpace(SpaceArgs{Name: "foo"}),
+		},
+	}
+
+	bytes, err := yaml.Marshal(initial)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var source map[string]interface{}
+	err = yaml.Unmarshal(bytes, &source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	spaces, err := importSpaces(source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(spaces, jc.DeepEquals, initial.Spaces_)
+}
+
+func (s *SpaceSerializationSuite) TestParsingSerializedDataV2(c *gc.C) {
+	initial := spaces{
+		Version: 2,
+		Spaces_: []*space{
+			newSpace(SpaceArgs{
+				Id:         "1",
 				Name:       "special",
 				Public:     true,
 				ProviderID: "magic",


### PR DESCRIPTION
As per description, supports migration of spaces that will now include an ID.

I used a string for the ID instead of a tag as is done for machines, because the space tag is still intended to indicate a space name. This concept will be reviewed as we progress.