### PR TITLE
Add SpaceID and IsPublic to subnet, note SpaceName deprecated.

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -209,3 +209,20 @@ type StorageInstanceConstraints struct {
 	Pool string
 	Size uint64
 }
+
+// Subnet represents a network subnet.
+type Subnet interface {
+	ProviderId() string
+	ProviderNetworkId() string
+	ProviderSpaceId() string
+	CIDR() string
+	VLANTag() int
+	AvailabilityZones() []string
+	IsPublic() bool
+	SpaceID() string
+	SpaceName() string
+	FanLocalUnderlay() string
+	FanOverlay() string
+	AllocatableIPHigh() string
+	AllocatableIPLow() string
+}

--- a/interfaces.go
+++ b/interfaces.go
@@ -223,6 +223,4 @@ type Subnet interface {
 	SpaceName() string
 	FanLocalUnderlay() string
 	FanOverlay() string
-	AllocatableIPHigh() string
-	AllocatableIPLow() string
 }

--- a/model.go
+++ b/model.go
@@ -490,7 +490,7 @@ func (m *model) AddSubnet(args SubnetArgs) Subnet {
 
 func (m *model) setSubnets(subnetList []*subnet) {
 	m.Subnets_ = subnets{
-		Version:  4,
+		Version:  5,
 		Subnets_: subnetList,
 	}
 }
@@ -939,16 +939,16 @@ func (m *model) validateStorage(allMachineIDs, allApplications, allUnits set.Str
 
 // validateSubnets makes sure that any spaces referenced by subnets exist.
 func (m *model) validateSubnets() error {
-	spaceNames := set.NewStrings()
+	spaceIDs := set.NewStrings()
 	for _, space := range m.Spaces_.Spaces_ {
-		spaceNames.Add(space.Name())
+		spaceIDs.Add(space.Id())
 	}
 	for _, subnet := range m.Subnets_.Subnets_ {
-		if subnet.SpaceName() == "" {
+		if subnet.SpaceID() == "" {
 			continue
 		}
-		if !spaceNames.Contains(subnet.SpaceName()) {
-			return errors.Errorf("subnet %q references non-existent space %q", subnet.CIDR(), subnet.SpaceName())
+		if !spaceIDs.Contains(subnet.SpaceID()) {
+			return errors.Errorf("subnet %q references non-existent space %q", subnet.CIDR(), subnet.SpaceID())
 		}
 	}
 

--- a/model_test.go
+++ b/model_test.go
@@ -495,11 +495,11 @@ func (s *ModelSerializationSuite) TestModelSerializationWithRelations(c *gc.C) {
 
 func (s *ModelSerializationSuite) TestModelValidationChecksSubnets(c *gc.C) {
 	model := s.newModel(ModelArgs{Owner: names.NewUserTag("owner")})
-	model.AddSubnet(SubnetArgs{CIDR: "10.0.0.0/24", SpaceName: "foo"})
+	model.AddSubnet(SubnetArgs{CIDR: "10.0.0.0/24", SpaceID: "3"})
 	model.AddSubnet(SubnetArgs{CIDR: "10.0.1.0/24"})
 	err := model.Validate()
-	c.Assert(err, gc.ErrorMatches, `subnet "10.0.0.0/24" references non-existent space "foo"`)
-	model.AddSpace(SpaceArgs{Name: "foo"})
+	c.Assert(err, gc.ErrorMatches, `subnet "10.0.0.0/24" references non-existent space "3"`)
+	model.AddSpace(SpaceArgs{Id: "3"})
 	err = model.Validate()
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/remoteapplication_test.go
+++ b/remoteapplication_test.go
@@ -70,6 +70,8 @@ func minimalRemoteApplicationMap() map[interface{}]interface{} {
 					"version": 3,
 					"subnets": []interface{}{map[interface{}]interface{}{
 						"cidr":                "2.3.4.0/24",
+						"is-public":           false,
+						"space-id":            "",
 						"space-name":          "",
 						"vlan-tag":            0,
 						"provider-id":         "juju-subnet-1",

--- a/remotespace_test.go
+++ b/remotespace_test.go
@@ -39,6 +39,8 @@ func minimalRemoteSpaceMap() map[interface{}]interface{} {
 			"version": 3,
 			"subnets": []interface{}{map[interface{}]interface{}{
 				"cidr":                "2.3.4.0/24",
+				"is-public":           false,
+				"space-id":            "",
 				"space-name":          "a-space",
 				"vlan-tag":            64,
 				"provider-id":         "juju-subnet-1",

--- a/subnet.go
+++ b/subnet.go
@@ -29,11 +29,6 @@ type subnet struct {
 
 	FanLocalUnderlay_ string `yaml:"fan-local-underlay,omitempty"`
 	FanOverlay_       string `yaml:"fan-overlay,omitempty"`
-
-	// These will be deprecated once the address allocation strategy for
-	// EC2 is changed. They are unused already on MAAS.
-	AllocatableIPHigh_ string `yaml:"allocatable-ip-high,omitempty"`
-	AllocatableIPLow_  string `yaml:"allocatable-ip-low,omitempty"`
 }
 
 // SubnetArgs is an argument struct used to create a
@@ -53,11 +48,6 @@ type SubnetArgs struct {
 	SpaceID           string
 	FanLocalUnderlay  string
 	FanOverlay        string
-
-	// These will be deprecated once the address allocation strategy for
-	// EC2 is changed. They are unused already on MAAS.
-	AllocatableIPHigh string
-	AllocatableIPLow  string
 }
 
 func newSubnet(args SubnetArgs) *subnet {
@@ -73,8 +63,6 @@ func newSubnet(args SubnetArgs) *subnet {
 		IsPublic_:          args.IsPublic,
 		FanLocalUnderlay_:  args.FanLocalUnderlay,
 		FanOverlay_:        args.FanOverlay,
-		AllocatableIPHigh_: args.AllocatableIPHigh,
-		AllocatableIPLow_:  args.AllocatableIPLow,
 	}
 }
 
@@ -133,16 +121,6 @@ func (s *subnet) FanOverlay() string {
 	return s.FanOverlay_
 }
 
-// AllocatableIPHigh implements Subnet.
-func (s *subnet) AllocatableIPHigh() string {
-	return s.AllocatableIPHigh_
-}
-
-// AllocatableIPLow implements Subnet.
-func (s *subnet) AllocatableIPLow() string {
-	return s.AllocatableIPLow_
-}
-
 func importSubnets(source map[string]interface{}) ([]*subnet, error) {
 	checker := versionedChecker("subnets")
 	coerced, err := checker.Coerce(source, nil)
@@ -196,8 +174,6 @@ func newSubnetFromValid(valid map[string]interface{}, version int) (*subnet, err
 		CIDR_:              valid["cidr"].(string),
 		ProviderId_:        valid["provider-id"].(string),
 		VLANTag_:           int(valid["vlan-tag"].(int64)),
-		AllocatableIPHigh_: valid["allocatable-ip-high"].(string),
-		AllocatableIPLow_:  valid["allocatable-ip-low"].(string),
 	}
 	if version >= 2 {
 		result.ProviderNetworkId_ = valid["provider-network-id"].(string)

--- a/subnet_test.go
+++ b/subnet_test.go
@@ -63,8 +63,6 @@ func testSubnetArgs() SubnetArgs {
 		FanLocalUnderlay:  "1.2.3.4/24",
 		FanOverlay:        "253.0.0.0/8",
 		AvailabilityZones: []string{"bar", "baz"},
-		AllocatableIPHigh: "10.0.0.255",
-		AllocatableIPLow:  "10.0.0.0",
 	}
 }
 
@@ -80,8 +78,6 @@ func (s *SubnetSerializationSuite) TestNewSubnet(c *gc.C) {
 	c.Assert(subnet.SpaceID(), gc.Equals, args.SpaceID)
 	c.Assert(subnet.IsPublic(), jc.IsTrue)
 	c.Assert(subnet.AvailabilityZones(), gc.DeepEquals, args.AvailabilityZones)
-	c.Assert(subnet.AllocatableIPHigh(), gc.Equals, args.AllocatableIPHigh)
-	c.Assert(subnet.AllocatableIPLow(), gc.Equals, args.AllocatableIPLow)
 }
 
 func (s *SubnetSerializationSuite) exportImport(c *gc.C, subnet_ *subnet, version int) *subnet {


### PR DESCRIPTION
Adds new subnet serialization for V5, supporting spaceID and IsPublic; removing spaceName.

spaceID as a string follows the precedence of work done to add ID to space migrations.
