### PR TITLE
update model.validateSubnet().

### DIFF
--- a/model.go
+++ b/model.go
@@ -944,7 +944,9 @@ func (m *model) validateSubnets() error {
 		spaceIDs.Add(space.Id())
 	}
 	for _, subnet := range m.Subnets_.Subnets_ {
-		if subnet.SpaceID() == "" {
+		// space "0" is the new, in juju 2.7, default space,
+		// created with each new model.
+		if subnet.SpaceID() == "" || subnet.SpaceID() == "0"{
 			continue
 		}
 		if !spaceIDs.Contains(subnet.SpaceID()) {

--- a/model_test.go
+++ b/model_test.go
@@ -1002,11 +1002,12 @@ func (s *ModelSerializationSuite) TestLinkLayerDevice(c *gc.C) {
 
 func (s *ModelSerializationSuite) TestSubnets(c *gc.C) {
 	initial := s.newModel(ModelArgs{Owner: names.NewUserTag("owner")})
+	initial.AddSubnet(SubnetArgs{CIDR: "10.0.20.0/24", SpaceID:"0"})
 	subnet := initial.AddSubnet(SubnetArgs{CIDR: "10.0.0.0/24"})
 	c.Assert(subnet.CIDR(), gc.Equals, "10.0.0.0/24")
 	subnets := initial.Subnets()
-	c.Assert(subnets, gc.HasLen, 1)
-	c.Assert(subnets[0], jc.DeepEquals, subnet)
+	c.Assert(subnets, gc.HasLen, 2)
+	c.Assert(subnets[1], jc.DeepEquals, subnet)
 
 	bytes, err := yaml.Marshal(initial)
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
Don't check for the default space of "0" existing in model.validateSubnet().  Juju does not export it during migrations, as it is created for every new model.