### PR TITLE
Adds version 2 of Address that supports the presence of space IDs

### DIFF
--- a/address.go
+++ b/address.go
@@ -14,24 +14,27 @@ type Address interface {
 	Type() string
 	Scope() string
 	Origin() string
+	SpaceID() string
 }
 
 // AddressArgs is an argument struct used to create a new internal address
 // type that supports the Address interface.
 type AddressArgs struct {
-	Value  string
-	Type   string
-	Scope  string
-	Origin string
+	Value   string
+	Type    string
+	Scope   string
+	Origin  string
+	SpaceID string
 }
 
 func newAddress(args AddressArgs) *address {
 	return &address{
-		Version: 1,
-		Value_:  args.Value,
-		Type_:   args.Type,
-		Scope_:  args.Scope,
-		Origin_: args.Origin,
+		Version:  2,
+		Value_:   args.Value,
+		Type_:    args.Type,
+		Scope_:   args.Scope,
+		Origin_:  args.Origin,
+		SpaceID_: args.SpaceID,
 	}
 }
 
@@ -39,10 +42,11 @@ func newAddress(args AddressArgs) *address {
 type address struct {
 	Version int `yaml:"version"`
 
-	Value_  string `yaml:"value"`
-	Type_   string `yaml:"type"`
-	Scope_  string `yaml:"scope,omitempty"`
-	Origin_ string `yaml:"origin,omitempty"`
+	Value_   string `yaml:"value"`
+	Type_    string `yaml:"type"`
+	Scope_   string `yaml:"scope,omitempty"`
+	Origin_  string `yaml:"origin,omitempty"`
+	SpaceID_ string `yaml:"spaceid,omitempty"`
 }
 
 // Value implements Address.
@@ -63,6 +67,11 @@ func (a *address) Scope() string {
 // Origin implements Address.
 func (a *address) Origin() string {
 	return a.Origin_
+}
+
+// SpaceID implements Address.
+func (a *address) SpaceID() string {
+	return a.SpaceID_
 }
 
 func importAddresses(sourceList []interface{}) ([]*address, error) {
@@ -101,20 +110,11 @@ type addressDeserializationFunc func(map[string]interface{}) (*address, error)
 
 var addressDeserializationFuncs = map[int]addressDeserializationFunc{
 	1: importAddressV1,
+	2: importAddressV2,
 }
 
 func importAddressV1(source map[string]interface{}) (*address, error) {
-	fields := schema.Fields{
-		"value":  schema.String(),
-		"type":   schema.String(),
-		"scope":  schema.String(),
-		"origin": schema.String(),
-	}
-	// Some values don't have to be there.
-	defaults := schema.Defaults{
-		"scope":  "",
-		"origin": "",
-	}
+	fields, defaults := addressV1Fields()
 	checker := schema.FieldMap(fields, defaults)
 
 	coerced, err := checker.Coerce(source, nil)
@@ -132,4 +132,53 @@ func importAddressV1(source map[string]interface{}) (*address, error) {
 		Scope_:  valid["scope"].(string),
 		Origin_: valid["origin"].(string),
 	}, nil
+}
+
+func importAddressV2(source map[string]interface{}) (*address, error) {
+	fields, defaults := addressV1Fields()
+	fields["spaceid"] = schema.String()
+
+	// We must allow for an empty space ID because:
+	// - newAddress always returns a V2 address.
+	// - newAddress is called by methods in Machine that do not negotiate a
+	//   version.
+	// If an old version of Juju not supporting address spaces upgrades to this
+	// version of the library, we need to allow export and import of V2
+	// addresses that tolerate a missing space ID.
+	// Ensuring correct defaults for this field must be ensured in the Juju
+	// migration code itself.
+	defaults["spaceid"] = ""
+	checker := schema.FieldMap(fields, defaults)
+
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "address v1 schema check failed")
+	}
+	valid := coerced.(map[string]interface{})
+	// From here we know that the map returned from the schema coercion
+	// contains fields of the right type.
+
+	return &address{
+		Version:  2,
+		Value_:   valid["value"].(string),
+		Type_:    valid["type"].(string),
+		Scope_:   valid["scope"].(string),
+		Origin_:  valid["origin"].(string),
+		SpaceID_: valid["spaceid"].(string),
+	}, nil
+}
+
+func addressV1Fields() (schema.Fields, schema.Defaults) {
+	fields := schema.Fields{
+		"value":  schema.String(),
+		"type":   schema.String(),
+		"scope":  schema.String(),
+		"origin": schema.String(),
+	}
+	// Some values don't have to be there.
+	defaults := schema.Defaults{
+		"scope":  "",
+		"origin": "",
+	}
+	return fields, defaults
 }

--- a/address_test.go
+++ b/address_test.go
@@ -75,13 +75,36 @@ func (*AddressSerializationSuite) TestOptionalValues(c *gc.C) {
 	c.Assert(addr, jc.DeepEquals, expected)
 }
 
-func (*AddressSerializationSuite) TestParsingSerializedData(c *gc.C) {
+func (*AddressSerializationSuite) TestParsingSerializedDataV1(c *gc.C) {
 	initial := &address{
 		Version: 1,
 		Value_:  "no",
 		Type_:   "content",
 		Scope_:  "done",
 		Origin_: "here",
+	}
+
+	bytes, err := yaml.Marshal(initial)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var source map[string]interface{}
+	err = yaml.Unmarshal(bytes, &source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	addresss, err := importAddress(source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(addresss, jc.DeepEquals, initial)
+}
+
+func (*AddressSerializationSuite) TestParsingSerializedDataV2(c *gc.C) {
+	initial := &address{
+		Version:  2,
+		Value_:   "no",
+		Type_:    "content",
+		Scope_:   "done",
+		Origin_:  "here",
+		SpaceID_: "666",
 	}
 
 	bytes, err := yaml.Marshal(initial)

--- a/application_test.go
+++ b/application_test.go
@@ -90,8 +90,8 @@ func minimalApplicationMapCAAS() map[interface{}]interface{} {
 		"version":     1,
 		"provider-id": "some-provider",
 		"addresses": []interface{}{
-			map[interface{}]interface{}{"version": 1, "value": "10.0.0.1", "type": "special"},
-			map[interface{}]interface{}{"version": 1, "value": "10.0.0.2", "type": "other"},
+			map[interface{}]interface{}{"version": 2, "value": "10.0.0.1", "type": "special"},
+			map[interface{}]interface{}{"version": 2, "value": "10.0.0.2", "type": "other"},
 		},
 	}
 	result["units"] = map[interface{}]interface{}{

--- a/cloudcontainer_test.go
+++ b/cloudcontainer_test.go
@@ -41,7 +41,7 @@ func (s *CloudContainerSerializationSuite) TestAllArgs(c *gc.C) {
 	container := newCloudContainer(&args)
 
 	c.Check(container.ProviderId(), gc.Equals, args.ProviderId)
-	c.Check(container.Address(), jc.DeepEquals, &address{Version: 1, Value_: "10.0.0.1", Type_: "special"})
+	c.Check(container.Address(), jc.DeepEquals, &address{Version: 2, Value_: "10.0.0.1", Type_: "special"})
 
 	c.Check(container.Ports(), jc.DeepEquals, args.Ports)
 }

--- a/cloudservice_test.go
+++ b/cloudservice_test.go
@@ -43,8 +43,8 @@ func (s *CloudServiceSerializationSuite) TestAllArgs(c *gc.C) {
 
 	c.Check(container.ProviderId(), gc.Equals, args.ProviderId)
 	c.Check(container.Addresses(), jc.DeepEquals, []Address{
-		&address{Version: 1, Value_: "10.0.0.1", Type_: "special"},
-		&address{Version: 1, Value_: "10.0.0.2", Type_: "other"},
+		&address{Version: 2, Value_: "10.0.0.1", Type_: "special"},
+		&address{Version: 2, Value_: "10.0.0.2", Type_: "other"},
 	})
 }
 

--- a/unit_test.go
+++ b/unit_test.go
@@ -56,7 +56,7 @@ func minimalUnitMapCAAS() map[interface{}]interface{} {
 	result["cloud-container"] = map[interface{}]interface{}{
 		"version":     1,
 		"provider-id": "some-provider",
-		"address":     map[interface{}]interface{}{"version": 1, "value": "10.0.0.1", "type": "special"},
+		"address":     map[interface{}]interface{}{"version": 2, "value": "10.0.0.1", "type": "special"},
 		"ports":       []interface{}{"80", "443"},
 	}
 	return result


### PR DESCRIPTION
Adds version 2 of Address that supports the presence of space IDs.

Note the comment against the empty string default for space ID. Because *any* importer of newer versions of this library will be adding addresses with version 2, we need to tolerate the missing space.

It will be the responsibility of Juju migration logic to add sensible defaults I.e. "0" for addresses in 2.7 and beyond.