### PR TITLE
Remote app omitempty for status field

### DIFF
--- a/remoteapplication.go
+++ b/remoteapplication.go
@@ -44,7 +44,7 @@ type remoteApplication struct {
 	IsConsumerProxy_ bool              `yaml:"is-consumer-proxy,omitempty"`
 	Spaces_          remoteSpaces      `yaml:"spaces,omitempty"`
 	Bindings_        map[string]string `yaml:"bindings,omitempty"`
-	Status_          *status           `yaml:"status"`
+	Status_          *status           `yaml:"status,omitempty"`
 }
 
 // RemoteApplicationArgs is an argument struct used to add a remote
@@ -220,7 +220,7 @@ func newRemoteApplicationFromValid(valid map[string]interface{}, version int) (*
 		IsConsumerProxy_: valid["is-consumer-proxy"].(bool),
 	}
 
-	if rawStatus := valid["status"]; rawStatus != nil {
+	if rawStatus, ok := valid["status"]; ok && rawStatus != nil {
 		status, err := importStatus(rawStatus.(map[string]interface{}))
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -267,6 +267,7 @@ func remoteApplicationV1Fields() (schema.Fields, schema.Defaults) {
 		"endpoints":         schema.Omit,
 		"spaces":            schema.Omit,
 		"bindings":          schema.Omit,
+		"status":            schema.Omit,
 		"is-consumer-proxy": false,
 	}
 	return fields, defaults


### PR DESCRIPTION
The following commit ensures that we use omitempty for the status
field on a remote application. It's highly possible that not all
remote applications will have a status field. It even states this
in the documentation for the export migration in the juju/juju.

The tests also ensure that we test for missing status field and
the code correctly parses the remote application, with and without
a status field.