### PR TITLE
External controller models

### DIFF
--- a/externalcontroller.go
+++ b/externalcontroller.go
@@ -16,6 +16,7 @@ type ExternalController interface {
 	Alias() string
 	Addrs() []string
 	CACert() string
+	Models() []string
 }
 
 type externalControllers struct {
@@ -28,6 +29,7 @@ type externalController struct {
 	Alias_  string   `yaml:"alias,omitempty"`
 	Addrs_  []string `yaml:"addrs"`
 	CACert_ string   `yaml:"ca-cert"`
+	Models_ []string `yaml:"models"`
 }
 
 // ExternalControllerArgs is an argument struct used to add a external
@@ -37,6 +39,7 @@ type ExternalControllerArgs struct {
 	Alias  string
 	Addrs  []string
 	CACert string
+	Models []string
 }
 
 func newExternalController(args ExternalControllerArgs) *externalController {
@@ -45,6 +48,7 @@ func newExternalController(args ExternalControllerArgs) *externalController {
 		Alias_:  args.Alias,
 		Addrs_:  args.Addrs,
 		CACert_: args.CACert,
+		Models_: args.Models,
 	}
 }
 
@@ -66,6 +70,11 @@ func (e *externalController) Addrs() []string {
 // CACert returns the ca cert for the external controller.
 func (e *externalController) CACert() string {
 	return e.CACert_
+}
+
+// Models returns the list of models for the external controller.
+func (e *externalController) Models() []string {
+	return e.Models_
 }
 
 func importExternalControllers(source interface{}) ([]*externalController, error) {
@@ -114,6 +123,7 @@ func externalControllerV1Fields() (schema.Fields, schema.Defaults) {
 		"alias":   schema.String(),
 		"addrs":   schema.List(schema.String()),
 		"ca-cert": schema.String(),
+		"models":  schema.List(schema.String()),
 	}
 	defaults := schema.Defaults{
 		"alias": schema.Omit,
@@ -137,6 +147,7 @@ func importExternalController(fields schema.Fields, defaults schema.Defaults, im
 		Alias_:  valid["alias"].(string),
 		Addrs_:  convertToStringSlice(valid["addrs"]),
 		CACert_: valid["ca-cert"].(string),
+		Models_: convertToStringSlice(valid["models"]),
 	}
 
 	return result, nil

--- a/externalcontroller_test.go
+++ b/externalcontroller_test.go
@@ -37,6 +37,9 @@ func minimalExternalControllerMap() map[interface{}]interface{} {
 			"0.0.0.1",
 		},
 		"ca-cert": "magic-cert",
+		"models": []interface{}{
+			"aaaa-bbbb",
+		},
 	}
 }
 
@@ -49,6 +52,9 @@ func minimalExternalController() *externalController {
 			"0.0.0.1",
 		},
 		CACert: "magic-cert",
+		Models: []string{
+			"aaaa-bbbb",
+		},
 	})
 	return c
 }
@@ -60,6 +66,9 @@ func (*ExternalControllerSerializationSuite) TestNew(c *gc.C) {
 		"1.2.3.4/24",
 		"0.0.0.1",
 	})
+	c.Check(e.Alias(), gc.Equals, "ext-ctrl-alias")
+	c.Check(e.CACert(), gc.Equals, "magic-cert")
+	c.Check(e.Models(), gc.DeepEquals, []string{"aaaa-bbbb"})
 }
 
 func (*ExternalControllerSerializationSuite) TestBadSchema1(c *gc.C) {

--- a/model_test.go
+++ b/model_test.go
@@ -987,6 +987,7 @@ func (s *ModelSerializationSuite) TestSerializesExternalControllers(c *gc.C) {
 		Alias:  "moon-ball",
 		Addrs:  []string{"1.2.3.4", "10.12.11.243"},
 		CACert: "magic-cert",
+		Models: []string{"aaaa-bbbb"},
 	})
 	data := asStringMap(c, model)
 	ctrlSection, ok := data["external-controllers"]
@@ -1004,6 +1005,8 @@ external-controllers:
   alias: moon-ball
   ca-cert: magic-cert
   id: controller-name
+  models:
+  - aaaa-bbbb
 version: 1
 `[1:]
 	c.Assert(string(bytes), gc.Equals, expected)
@@ -1016,6 +1019,7 @@ func (s *ModelSerializationSuite) TestImportingWithExternalControllers(c *gc.C) 
 		Alias:  "moon-ball",
 		Addrs:  []string{"1.2.3.4", "10.12.11.243"},
 		CACert: "magic-cert",
+		Models: []string{"aaaa-bbbb"},
 	})
 	offerConnections := initial.ExternalControllers()
 


### PR DESCRIPTION
The following is the missing ModelUUIDs from an external controller, which we 
will need to export the models for an external controller, that way we can
build up an external controller document correctly for CMR.
