### PR TITLE
Optional external controller alias

### DIFF
--- a/externalcontroller.go
+++ b/externalcontroller.go
@@ -144,10 +144,15 @@ func importExternalController(fields schema.Fields, defaults schema.Defaults, im
 	// contains fields of the right type.
 	result := &externalController{
 		ID_:     valid["id"].(string),
-		Alias_:  valid["alias"].(string),
 		Addrs_:  convertToStringSlice(valid["addrs"]),
 		CACert_: valid["ca-cert"].(string),
 		Models_: convertToStringSlice(valid["models"]),
+	}
+
+	// Alias is optional through out juju and because of that, it isn't a
+	// requirement of external controller migrations.
+	if alias, ok := valid["alias"]; ok {
+		result.Alias_ = alias.(string)
 	}
 
 	return result, nil

--- a/externalcontroller_test.go
+++ b/externalcontroller_test.go
@@ -101,6 +101,19 @@ func (*ExternalControllerSerializationSuite) TestMinimalMatches(c *gc.C) {
 	c.Assert(source, jc.DeepEquals, minimalExternalControllerMap())
 }
 
+func (*ExternalControllerSerializationSuite) TestMinimalMatchesWithoutAlias(c *gc.C) {
+	m := minimalExternalControllerMap()
+	delete(m, "alias")
+
+	bytes, err := yaml.Marshal(m)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var source map[interface{}]interface{}
+	err = yaml.Unmarshal(bytes, &source)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(source, jc.DeepEquals, m)
+}
+
 func (s *ExternalControllerSerializationSuite) TestRoundTrip(c *gc.C) {
 	rIn := minimalExternalController()
 	rOut := s.exportImport(c, rIn)


### PR DESCRIPTION
As juju doesn't always talk about controller names directly, mostly as
UUIDs we don't always have an alias for controllers. With that in mind
it is best not to request the alias in a map if it's empty.

The code changes that setup and instead only asks for the alias if it's
found. Otherwise the alias is ignored and a default string valus is
used.

This should prevent the panic during migrating consumers to another
controller.