### PR TITLE
Include Macaroon in Remote Applications

### DIFF
--- a/model.go
+++ b/model.go
@@ -876,7 +876,7 @@ func (m *model) AddRemoteApplication(args RemoteApplicationArgs) RemoteApplicati
 
 func (m *model) setRemoteApplications(appList []*remoteApplication) {
 	m.RemoteApplications_ = remoteApplications{
-		Version:            1,
+		Version:            2,
 		RemoteApplications: appList,
 	}
 }

--- a/model_test.go
+++ b/model_test.go
@@ -869,7 +869,7 @@ remote-applications:
       value: running
     version: 2
   url: other.mysql
-version: 1
+version: 2
 `[1:]
 	c.Assert(string(bytes), gc.Equals, expected)
 }

--- a/remoteapplication_test.go
+++ b/remoteapplication_test.go
@@ -8,7 +8,7 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	names "gopkg.in/juju/names.v3"
+	"gopkg.in/juju/names.v3"
 	"gopkg.in/yaml.v2"
 )
 
@@ -239,22 +239,31 @@ func (*RemoteApplicationSerializationSuite) TestMinimalMatchesWithoutStatus(c *g
 	c.Assert(source, jc.DeepEquals, minimalRemoteApplicationMapWithoutStatus())
 }
 
-func (s *RemoteApplicationSerializationSuite) TestRoundTrip(c *gc.C) {
+func (s *RemoteApplicationSerializationSuite) TestRoundTripVersion1(c *gc.C) {
 	rIn := minimalRemoteApplication()
-	rOut := s.exportImport(c, rIn)
+	rOut := s.exportImport(c, 1, rIn)
+	c.Assert(rOut, jc.DeepEquals, rIn)
+}
+
+func (s *RemoteApplicationSerializationSuite) TestRoundTripVersion2(c *gc.C) {
+	rIn := minimalRemoteApplication()
+	rIn.Macaroon_ = "mac"
+	rOut := s.exportImport(c, 2, rIn)
 	c.Assert(rOut, jc.DeepEquals, rIn)
 }
 
 func (s *RemoteApplicationSerializationSuite) TestRoundTripWithoutStatus(c *gc.C) {
 	rIn := minimalRemoteApplicationWithoutStatus()
-	rOut := s.exportImport(c, rIn)
+	rOut := s.exportImport(c, 1, rIn)
 	c.Assert(rOut, jc.DeepEquals, rIn)
 }
 
-func (s *RemoteApplicationSerializationSuite) exportImport(c *gc.C, applicationIn *remoteApplication) *remoteApplication {
+func (s *RemoteApplicationSerializationSuite) exportImport(
+	c *gc.C, version int, app *remoteApplication,
+) *remoteApplication {
 	applicationsIn := &remoteApplications{
-		Version:            1,
-		RemoteApplications: []*remoteApplication{applicationIn},
+		Version:            version,
+		RemoteApplications: []*remoteApplication{app},
 	}
 	bytes, err := yaml.Marshal(applicationsIn)
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
Adds version 2 for remote applications, which includes the macaroon used to authorise CMR consumers.

