### PR TITLE
Ensure that application units are exported with V3 unit payloads

### DIFF
--- a/application.go
+++ b/application.go
@@ -357,7 +357,7 @@ func (a *application) AddUnit(args UnitArgs) Unit {
 
 func (a *application) setUnits(unitList []*unit) {
 	a.Units_ = units{
-		Version: 2,
+		Version: 3,
 		Units_:  unitList,
 	}
 }

--- a/application_test.go
+++ b/application_test.go
@@ -60,7 +60,7 @@ func minimalApplicationMap() map[interface{}]interface{} {
 			},
 		},
 		"units": map[interface{}]interface{}{
-			"version": 2,
+			"version": 3,
 			"units": []interface{}{
 				minimalUnitMap(),
 			},
@@ -95,7 +95,7 @@ func minimalApplicationMapCAAS() map[interface{}]interface{} {
 		},
 	}
 	result["units"] = map[interface{}]interface{}{
-		"version": 2,
+		"version": 3,
 		"units": []interface{}{
 			minimalUnitMapCAAS(),
 		},

--- a/unit_test.go
+++ b/unit_test.go
@@ -47,6 +47,9 @@ func minimalUnitMap() map[interface{}]interface{} {
 			"version":  1,
 			"payloads": []interface{}{},
 		},
+		"state": map[interface{}]interface{}{
+			"charm-state": "0xbadc0ffee",
+		},
 	}
 }
 
@@ -89,6 +92,9 @@ func minimalUnitArgs(modelType string) UnitArgs {
 		Type:         modelType,
 		Machine:      names.NewMachineTag("0"),
 		PasswordHash: "secure-hash",
+		State: map[string]string{
+			"charm-state": "0xbadc0ffee",
+		},
 	}
 	if modelType == CAAS {
 		result.CloudContainer = &CloudContainerArgs{
@@ -212,6 +218,7 @@ func (s *UnitSerializationSuite) TestV1ParsingReturnsLatest(c *gc.C) {
 	unitLatest := minimalUnit()
 	unitLatest.CloudContainer_ = nil
 	unitLatest.Type_ = ""
+	unitLatest.State_ = nil
 
 	unitResult := s.exportImportVersion(c, unitV1, 1)
 	c.Assert(unitResult, jc.DeepEquals, unitLatest)


### PR DESCRIPTION
PR #72 defined the format for V3 unit payloads but lacked a change to ensure that application unit lists are actually exported with the latest unit payload version.