### PR TITLE
Add VirtualPortType to Link Layer Device schema

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -38,6 +38,7 @@ type LinkLayerDevice interface {
 	IsAutoStart() bool
 	IsUp() bool
 	ParentName() string
+	VirtualPortType() string
 }
 
 // IPAddress represents an IP address.

--- a/linklayerdevice.go
+++ b/linklayerdevice.go
@@ -14,15 +14,16 @@ type linklayerdevices struct {
 }
 
 type linklayerdevice struct {
-	Name_        string `yaml:"name"`
-	MTU_         uint   `yaml:"mtu"`
-	ProviderID_  string `yaml:"provider-id,omitempty"`
-	MachineID_   string `yaml:"machine-id"`
-	Type_        string `yaml:"type"`
-	MACAddress_  string `yaml:"mac-address"`
-	IsAutoStart_ bool   `yaml:"is-autostart"`
-	IsUp_        bool   `yaml:"is-up"`
-	ParentName_  string `yaml:"parent-name"`
+	Name_            string `yaml:"name"`
+	MTU_             uint   `yaml:"mtu"`
+	ProviderID_      string `yaml:"provider-id,omitempty"`
+	MachineID_       string `yaml:"machine-id"`
+	Type_            string `yaml:"type"`
+	MACAddress_      string `yaml:"mac-address"`
+	IsAutoStart_     bool   `yaml:"is-autostart"`
+	IsUp_            bool   `yaml:"is-up"`
+	ParentName_      string `yaml:"parent-name"`
+	VirtualPortType_ string `yaml:"virtual-port-type,omitempty"`
 }
 
 // ProviderID implements LinkLayerDevice.
@@ -70,31 +71,38 @@ func (i *linklayerdevice) ParentName() string {
 	return i.ParentName_
 }
 
+// VirtualPortType implements LinkLayerDevice.
+func (i *linklayerdevice) VirtualPortType() string {
+	return i.VirtualPortType_
+}
+
 // LinkLayerDeviceArgs is an argument struct used to create a
 // new internal linklayerdevice type that supports the LinkLayerDevice interface.
 type LinkLayerDeviceArgs struct {
-	Name        string
-	MTU         uint
-	ProviderID  string
-	MachineID   string
-	Type        string
-	MACAddress  string
-	IsAutoStart bool
-	IsUp        bool
-	ParentName  string
+	Name            string
+	MTU             uint
+	ProviderID      string
+	MachineID       string
+	Type            string
+	MACAddress      string
+	IsAutoStart     bool
+	IsUp            bool
+	ParentName      string
+	VirtualPortType string
 }
 
 func newLinkLayerDevice(args LinkLayerDeviceArgs) *linklayerdevice {
 	return &linklayerdevice{
-		ProviderID_:  args.ProviderID,
-		MachineID_:   args.MachineID,
-		Name_:        args.Name,
-		MTU_:         args.MTU,
-		Type_:        args.Type,
-		MACAddress_:  args.MACAddress,
-		IsAutoStart_: args.IsAutoStart,
-		IsUp_:        args.IsUp,
-		ParentName_:  args.ParentName,
+		ProviderID_:      args.ProviderID,
+		MachineID_:       args.MachineID,
+		Name_:            args.Name,
+		MTU_:             args.MTU,
+		Type_:            args.Type,
+		MACAddress_:      args.MACAddress,
+		IsAutoStart_:     args.IsAutoStart,
+		IsUp_:            args.IsUp,
+		ParentName_:      args.ParentName,
+		VirtualPortType_: args.VirtualPortType,
 	}
 }
 
@@ -135,9 +143,50 @@ type linklayerdeviceDeserializationFunc func(map[string]interface{}) (*linklayer
 
 var linklayerdeviceDeserializationFuncs = map[int]linklayerdeviceDeserializationFunc{
 	1: importLinkLayerDeviceV1,
+	2: importLinkLayerDeviceV2,
 }
 
 func importLinkLayerDeviceV1(source map[string]interface{}) (*linklayerdevice, error) {
+	fields, defaults := linkLayerDeviceV1Schema()
+	checker := schema.FieldMap(fields, defaults)
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "linklayerdevice v1 schema check failed")
+	}
+	return linkLayerDeviceV1(coerced.(map[string]interface{})), nil
+}
+
+func importLinkLayerDeviceV2(source map[string]interface{}) (*linklayerdevice, error) {
+	fields, defaults := linkLayerDeviceV2Schema()
+	checker := schema.FieldMap(fields, defaults)
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "linklayerdevice v2 schema check failed")
+	}
+	return linkLayerDeviceV2(coerced.(map[string]interface{})), nil
+}
+
+func linkLayerDeviceV1(valid map[string]interface{}) *linklayerdevice {
+	return &linklayerdevice{
+		ProviderID_:  valid["provider-id"].(string),
+		MachineID_:   valid["machine-id"].(string),
+		Name_:        valid["name"].(string),
+		MTU_:         uint(valid["mtu"].(int64)),
+		Type_:        valid["type"].(string),
+		MACAddress_:  valid["mac-address"].(string),
+		IsAutoStart_: valid["is-autostart"].(bool),
+		IsUp_:        valid["is-up"].(bool),
+		ParentName_:  valid["parent-name"].(string),
+	}
+}
+
+func linkLayerDeviceV2(valid map[string]interface{}) *linklayerdevice {
+	lld := linkLayerDeviceV1(valid)
+	lld.VirtualPortType_ = valid["virtual-port-type"].(string)
+	return lld
+}
+
+func linkLayerDeviceV1Schema() (schema.Fields, schema.Defaults) {
 	fields := schema.Fields{
 		"provider-id":  schema.String(),
 		"machine-id":   schema.String(),
@@ -153,22 +202,15 @@ func importLinkLayerDeviceV1(source map[string]interface{}) (*linklayerdevice, e
 	defaults := schema.Defaults{
 		"provider-id": "",
 	}
-	checker := schema.FieldMap(fields, defaults)
 
-	coerced, err := checker.Coerce(source, nil)
-	if err != nil {
-		return nil, errors.Annotatef(err, "linklayerdevice v1 schema check failed")
-	}
-	valid := coerced.(map[string]interface{})
-	return &linklayerdevice{
-		ProviderID_:  valid["provider-id"].(string),
-		MachineID_:   valid["machine-id"].(string),
-		Name_:        valid["name"].(string),
-		MTU_:         uint(valid["mtu"].(int64)),
-		Type_:        valid["type"].(string),
-		MACAddress_:  valid["mac-address"].(string),
-		IsAutoStart_: valid["is-autostart"].(bool),
-		IsUp_:        valid["is-up"].(bool),
-		ParentName_:  valid["parent-name"].(string),
-	}, nil
+	return fields, defaults
+}
+
+func linkLayerDeviceV2Schema() (schema.Fields, schema.Defaults) {
+	fields, defaults := linkLayerDeviceV1Schema()
+
+	fields["virtual-port-type"] = schema.String()
+	defaults["virtual-port-type"] = ""
+
+	return fields, defaults
 }

--- a/linklayerdevice_test.go
+++ b/linklayerdevice_test.go
@@ -29,15 +29,16 @@ func (s *LinkLayerDeviceSerializationSuite) SetUpTest(c *gc.C) {
 
 func (s *LinkLayerDeviceSerializationSuite) TestNewLinkLayerDevice(c *gc.C) {
 	args := LinkLayerDeviceArgs{
-		ProviderID:  "magic",
-		MachineID:   "bar",
-		Name:        "foo",
-		MTU:         54,
-		Type:        "loopback",
-		MACAddress:  "DEADBEEF",
-		IsAutoStart: true,
-		IsUp:        true,
-		ParentName:  "bam",
+		ProviderID:      "magic",
+		MachineID:       "bar",
+		Name:            "foo",
+		MTU:             54,
+		Type:            "loopback",
+		MACAddress:      "DEADBEEF",
+		IsAutoStart:     true,
+		IsUp:            true,
+		ParentName:      "bam",
+		VirtualPortType: "ovs",
 	}
 	device := newLinkLayerDevice(args)
 	c.Assert(device.ProviderID(), gc.Equals, args.ProviderID)
@@ -49,9 +50,10 @@ func (s *LinkLayerDeviceSerializationSuite) TestNewLinkLayerDevice(c *gc.C) {
 	c.Assert(device.IsAutoStart(), gc.Equals, args.IsAutoStart)
 	c.Assert(device.IsUp(), gc.Equals, args.IsUp)
 	c.Assert(device.ParentName(), gc.Equals, args.ParentName)
+	c.Assert(device.VirtualPortType(), gc.Equals, args.VirtualPortType)
 }
 
-func (s *LinkLayerDeviceSerializationSuite) TestParsingSerializedData(c *gc.C) {
+func (s *LinkLayerDeviceSerializationSuite) TestParsingSerializedDataV1(c *gc.C) {
 	initial := linklayerdevices{
 		Version: 1,
 		LinkLayerDevices_: []*linklayerdevice{
@@ -65,6 +67,40 @@ func (s *LinkLayerDeviceSerializationSuite) TestParsingSerializedData(c *gc.C) {
 				IsAutoStart: true,
 				IsUp:        true,
 				ParentName:  "bam",
+			}),
+			newLinkLayerDevice(LinkLayerDeviceArgs{Name: "weeee"}),
+		},
+	}
+
+	bytes, err := yaml.Marshal(initial)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var source map[string]interface{}
+	err = yaml.Unmarshal(bytes, &source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	devices, err := importLinkLayerDevices(source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(devices, jc.DeepEquals, initial.LinkLayerDevices_)
+}
+
+func (s *LinkLayerDeviceSerializationSuite) TestParsingSerializedDataV2(c *gc.C) {
+	initial := linklayerdevices{
+		Version: 2,
+		LinkLayerDevices_: []*linklayerdevice{
+			newLinkLayerDevice(LinkLayerDeviceArgs{
+				ProviderID:  "magic",
+				MachineID:   "bar",
+				Name:        "foo",
+				MTU:         54,
+				Type:        "loopback",
+				MACAddress:  "DEADBEEF",
+				IsAutoStart: true,
+				IsUp:        true,
+				ParentName:  "bam",
+				// V2 adds the VirtualPortType field
+				VirtualPortType: "ovs",
 			}),
 			newLinkLayerDevice(LinkLayerDeviceArgs{Name: "weeee"}),
 		},


### PR DESCRIPTION
Link layer devices now include a `VirtualPortType` field which indicates the type of virtual port that a NIC might (where applicable) be attached to (e.g. a port managed by an OVS bridge).

This PR updates the link layer device schema to include the new field.