### PR TITLE
Adding missing interface fields.

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -228,4 +228,8 @@ type FirewallRule interface {
 // help support multiple store locations.
 type CharmOrigin interface {
 	Source() string
+	ID() string
+	Hash() string
+	Revision() int
+	Channel() string
 }


### PR DESCRIPTION
The problem with defining interfaces where we don't consume them is that
we sometimes don't realise they're missing.