### PR TITLE
Add port ranges to machine description

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -49,8 +49,8 @@ type Machine interface {
 	BlockDevices() []BlockDevice
 	AddBlockDevice(BlockDeviceArgs) BlockDevice
 
-	OpenedPorts() []OpenedPorts
-	AddOpenedPorts(OpenedPortsArgs) OpenedPorts
+	OpenedPortRanges() MachinePortRanges
+	AddOpenedPortRange(OpenedPortRangeArgs)
 
 	Validate() error
 }
@@ -85,7 +85,7 @@ type machine struct {
 
 	Containers_ []*machine `yaml:"containers"`
 
-	OpenedPorts_ *versionedOpenedPorts `yaml:"opened-ports,omitempty"`
+	OpenedPortRanges_ *machinePortRanges `yaml:"opened-port-ranges,omitempty"`
 
 	Annotations_ `yaml:"annotations,omitempty"`
 
@@ -322,33 +322,28 @@ func (m *machine) AddContainer(args MachineArgs) Machine {
 	return container
 }
 
-// OpenedPorts implements Machine.
-func (m *machine) OpenedPorts() []OpenedPorts {
-	if m.OpenedPorts_ == nil {
-		return nil
+// OpenedPortRanges implements Machine.
+func (m *machine) OpenedPortRanges() MachinePortRanges {
+	if m.OpenedPortRanges_ == nil {
+		m.OpenedPortRanges_ = newMachinePortRanges()
 	}
-	var result []OpenedPorts
-	for _, ports := range m.OpenedPorts_.OpenedPorts_ {
-		result = append(result, ports)
-	}
-	return result
+	return m.OpenedPortRanges_
 }
 
-// AddOpenedPorts implements Machine.
-func (m *machine) AddOpenedPorts(args OpenedPortsArgs) OpenedPorts {
-	if m.OpenedPorts_ == nil {
-		m.OpenedPorts_ = &versionedOpenedPorts{Version: 1}
+// AddOpenedPortRange implements Machine.
+func (m *machine) AddOpenedPortRange(args OpenedPortRangeArgs) {
+	if m.OpenedPortRanges_ == nil {
+		m.OpenedPortRanges_ = newMachinePortRanges()
 	}
-	ports := newOpenedPorts(args)
-	m.OpenedPorts_.OpenedPorts_ = append(m.OpenedPorts_.OpenedPorts_, ports)
-	return ports
-}
 
-func (m *machine) setOpenedPorts(portsList []*openedPorts) {
-	m.OpenedPorts_ = &versionedOpenedPorts{
-		Version:      1,
-		OpenedPorts_: portsList,
+	if m.OpenedPortRanges_.ByUnit_[args.UnitName] == nil {
+		m.OpenedPortRanges_.ByUnit_[args.UnitName] = newUnitPortRanges()
 	}
+
+	m.OpenedPortRanges_.ByUnit_[args.UnitName].ByEndpoint_[args.EndpointName] = append(
+		m.OpenedPortRanges_.ByUnit_[args.UnitName].ByEndpoint_[args.EndpointName],
+		newUnitPortRange(args.FromPort, args.ToPort, args.Protocol),
+	)
 }
 
 // Constraints implements HasConstraints.
@@ -429,56 +424,34 @@ type machineDeserializationFunc func(map[string]interface{}) (*machine, error)
 
 var machineDeserializationFuncs = map[int]machineDeserializationFunc{
 	1: importMachineV1,
+	2: importMachineV2,
 }
 
 func importMachineV1(source map[string]interface{}) (*machine, error) {
-	fields := schema.Fields{
-		"id":                   schema.String(),
-		"nonce":                schema.String(),
-		"password-hash":        schema.String(),
-		"placement":            schema.String(),
-		"instance":             schema.StringMap(schema.Any()),
-		"series":               schema.String(),
-		"container-type":       schema.String(),
-		"jobs":                 schema.List(schema.String()),
-		"status":               schema.StringMap(schema.Any()),
-		"supported-containers": schema.List(schema.String()),
-		"tools":                schema.StringMap(schema.Any()),
-		"containers":           schema.List(schema.StringMap(schema.Any())),
-		"opened-ports":         schema.StringMap(schema.Any()),
-
-		"provider-addresses":        schema.List(schema.StringMap(schema.Any())),
-		"machine-addresses":         schema.List(schema.StringMap(schema.Any())),
-		"preferred-public-address":  schema.StringMap(schema.Any()),
-		"preferred-private-address": schema.StringMap(schema.Any()),
-
-		"block-devices": schema.StringMap(schema.Any()),
-	}
-
-	defaults := schema.Defaults{
-		"placement":      "",
-		"container-type": "",
-		// Even though we are expecting instance data for every machine,
-		// it isn't strictly necessary, so we allow it to not exist here.
-		"instance":                  schema.Omit,
-		"supported-containers":      schema.Omit,
-		"opened-ports":              schema.Omit,
-		"block-devices":             schema.Omit,
-		"provider-addresses":        schema.Omit,
-		"machine-addresses":         schema.Omit,
-		"preferred-public-address":  schema.Omit,
-		"preferred-private-address": schema.Omit,
-	}
-	addAnnotationSchema(fields, defaults)
-	addConstraintsSchema(fields, defaults)
-	addStatusHistorySchema(fields)
+	fields, defaults := machineSchemaV1()
 	checker := schema.FieldMap(fields, defaults)
 
 	coerced, err := checker.Coerce(source, nil)
 	if err != nil {
 		return nil, errors.Annotatef(err, "machine v1 schema check failed")
 	}
-	valid := coerced.(map[string]interface{})
+
+	return machineV1(coerced.(map[string]interface{}))
+}
+
+func importMachineV2(source map[string]interface{}) (*machine, error) {
+	fields, defaults := machineSchemaV2()
+	checker := schema.FieldMap(fields, defaults)
+
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "machine v2 schema check failed")
+	}
+
+	return machineV2(coerced.(map[string]interface{}))
+}
+
+func machineV1(valid map[string]interface{}) (*machine, error) {
 	// From here we know that the map returned from the schema coercion
 	// contains fields of the right type.
 	result := &machine{
@@ -588,11 +561,105 @@ func importMachineV1(source map[string]interface{}) (*machine, error) {
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		result.setOpenedPorts(portsList)
+
+		// Convert to the new open port ranges format. As subnets
+		// were never actively used by older controllers (ranges were
+		// opened to all subnets), we can emulate the original semantics
+		// by opening each range for all endpoints.
+		for _, portList := range portsList {
+			for _, pr := range portList.OpenPorts() {
+				result.AddOpenedPortRange(OpenedPortRangeArgs{
+					UnitName:     pr.UnitName(),
+					EndpointName: "",
+					FromPort:     pr.FromPort(),
+					ToPort:       pr.ToPort(),
+					Protocol:     pr.Protocol(),
+				})
+			}
+		}
 	}
 
 	return result, nil
 
+}
+
+func machineV2(valid map[string]interface{}) (*machine, error) {
+	mach, err := machineV1(valid)
+	if err != nil {
+		return nil, err
+	}
+
+	machPortRangesSource, ok := valid["opened-port-ranges"].(map[string]interface{})
+	if !ok {
+		return mach, nil
+	}
+
+	// V1 legacy ports have been converted to open port ranges by the V1
+	// machine parser. V2 machines *only* include port ranges so if present
+	// we can simply parse them and inject them into the parsed machine
+	// instance.
+	machPortRanges, err := importMachinePortRanges(machPortRangesSource)
+	if err != nil {
+		return nil, err
+	}
+
+	mach.OpenedPortRanges_ = machPortRanges
+	return mach, nil
+}
+
+func machineSchemaV1() (schema.Fields, schema.Defaults) {
+	fields := schema.Fields{
+		"id":                   schema.String(),
+		"nonce":                schema.String(),
+		"password-hash":        schema.String(),
+		"placement":            schema.String(),
+		"instance":             schema.StringMap(schema.Any()),
+		"series":               schema.String(),
+		"container-type":       schema.String(),
+		"jobs":                 schema.List(schema.String()),
+		"status":               schema.StringMap(schema.Any()),
+		"supported-containers": schema.List(schema.String()),
+		"tools":                schema.StringMap(schema.Any()),
+		"containers":           schema.List(schema.StringMap(schema.Any())),
+		"opened-ports":         schema.StringMap(schema.Any()),
+
+		"provider-addresses":        schema.List(schema.StringMap(schema.Any())),
+		"machine-addresses":         schema.List(schema.StringMap(schema.Any())),
+		"preferred-public-address":  schema.StringMap(schema.Any()),
+		"preferred-private-address": schema.StringMap(schema.Any()),
+
+		"block-devices": schema.StringMap(schema.Any()),
+	}
+
+	defaults := schema.Defaults{
+		"placement":      "",
+		"container-type": "",
+		// Even though we are expecting instance data for every machine,
+		// it isn't strictly necessary, so we allow it to not exist here.
+		"instance":                  schema.Omit,
+		"supported-containers":      schema.Omit,
+		"opened-ports":              schema.Omit,
+		"block-devices":             schema.Omit,
+		"provider-addresses":        schema.Omit,
+		"machine-addresses":         schema.Omit,
+		"preferred-public-address":  schema.Omit,
+		"preferred-private-address": schema.Omit,
+	}
+
+	addAnnotationSchema(fields, defaults)
+	addConstraintsSchema(fields, defaults)
+	addStatusHistorySchema(fields)
+
+	return fields, defaults
+}
+
+func machineSchemaV2() (schema.Fields, schema.Defaults) {
+	fields, defaults := machineSchemaV1()
+
+	fields["opened-port-ranges"] = schema.StringMap(schema.Any())
+	defaults["opened-port-ranges"] = schema.Omit
+
+	return fields, defaults
 }
 
 // AgentToolsArgs is an argument struct used to add information about the

--- a/machine.go
+++ b/machine.go
@@ -586,7 +586,7 @@ func machineV1(valid map[string]interface{}) (*machine, error) {
 func machineV2(valid map[string]interface{}) (*machine, error) {
 	mach, err := machineV1(valid)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 
 	machPortRangesSource, ok := valid["opened-port-ranges"].(map[string]interface{})
@@ -600,7 +600,7 @@ func machineV2(valid map[string]interface{}) (*machine, error) {
 	// instance.
 	machPortRanges, err := importMachinePortRanges(machPortRangesSource)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 
 	mach.OpenedPortRanges_ = machPortRanges

--- a/model.go
+++ b/model.go
@@ -410,7 +410,7 @@ func (m *model) AddMachine(args MachineArgs) Machine {
 
 func (m *model) setMachines(machineList []*machine) {
 	m.Machines_ = machines{
-		Version:   1,
+		Version:   2,
 		Machines_: machineList,
 	}
 }
@@ -1044,10 +1044,8 @@ func (m *model) validateMachine(machine Machine, allMachineIDs, unitsWithOpenPor
 		return errors.Trace(err)
 	}
 	allMachineIDs.Add(machine.Id())
-	for _, op := range machine.OpenedPorts() {
-		for _, pr := range op.OpenPorts() {
-			unitsWithOpenPorts.Add(pr.UnitName())
-		}
+	for unitName := range machine.OpenedPortRanges().ByUnit() {
+		unitsWithOpenPorts.Add(unitName)
 	}
 	for _, container := range machine.Containers() {
 		err := m.validateMachine(container, allMachineIDs, unitsWithOpenPorts)

--- a/model_test.go
+++ b/model_test.go
@@ -333,15 +333,12 @@ func (s *ModelSerializationSuite) TestModelValidationChecksMachinesGood(c *gc.C)
 func (s *ModelSerializationSuite) TestModelValidationChecksOpenPortsUnits(c *gc.C) {
 	model := s.newModel(ModelArgs{Owner: names.NewUserTag("owner"), CloudRegion: "some-region"})
 	machine := s.addMachineToModel(model, "0")
-	machine.AddOpenedPorts(OpenedPortsArgs{
-		OpenedPorts: []PortRangeArgs{
-			{
-				UnitName: "missing/0",
-				FromPort: 8080,
-				ToPort:   8080,
-				Protocol: "tcp",
-			},
-		},
+	machine.AddOpenedPortRange(OpenedPortRangeArgs{
+		UnitName:     "missing/0",
+		EndpointName: "",
+		FromPort:     8080,
+		ToPort:       8080,
+		Protocol:     "tcp",
 	})
 	err := model.Validate()
 	c.Assert(err.Error(), gc.Equals, "unknown unit names in open ports: [missing/0]")

--- a/port_ranges.go
+++ b/port_ranges.go
@@ -27,6 +27,17 @@ type UnitPortRange interface {
 	Protocol() string
 }
 
+// OpenedPortRangeArgs is an argument struct used to add a new port range to
+// a machine.
+type OpenedPortRangeArgs struct {
+	UnitName     string
+	EndpointName string
+
+	FromPort int
+	ToPort   int
+	Protocol string
+}
+
 type machinePortRanges struct {
 	Version int `yaml:"version"`
 

--- a/port_ranges.go
+++ b/port_ranges.go
@@ -1,0 +1,189 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package description
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/schema"
+)
+
+// MachinePortRanges represents a collection of port ranges that are open on a
+// particular machine.
+type MachinePortRanges interface {
+	ByUnit() map[string]UnitPortRanges
+}
+
+// UnitPortRanges represents the of port ranges opened by a particular Unit for
+// one or more endpoints.
+type UnitPortRanges interface {
+	ByEndpoint() map[string][]UnitPortRange
+}
+
+// UnitPortRange represents a contiguous port range opened by a unit.
+type UnitPortRange interface {
+	FromPort() int
+	ToPort() int
+	Protocol() string
+}
+
+type machinePortRanges struct {
+	Version int `yaml:"version"`
+
+	// The set of opened port ranges by unit.
+	ByUnit_ map[string]*unitPortRanges `yaml:"machine-port-ranges"`
+}
+
+func newMachinePortRanges() *machinePortRanges {
+	return &machinePortRanges{
+		Version: 1,
+		ByUnit_: make(map[string]*unitPortRanges),
+	}
+}
+
+// ByUnit implements MachinePortRanges.
+func (p *machinePortRanges) ByUnit() map[string]UnitPortRanges {
+	res := make(map[string]UnitPortRanges, len(p.ByUnit_))
+	for unitName, upr := range p.ByUnit_ {
+		res[unitName] = upr
+	}
+	return res
+}
+
+type unitPortRanges struct {
+	// The set of opened port ranges for each endpoint.
+	ByEndpoint_ map[string][]*unitPortRange `yaml:"unit-port-ranges"`
+}
+
+func newUnitPortRanges() *unitPortRanges {
+	return &unitPortRanges{
+		ByEndpoint_: make(map[string][]*unitPortRange),
+	}
+}
+
+// ByEndpoint implements UnitPortRanges.
+func (p *unitPortRanges) ByEndpoint() map[string][]UnitPortRange {
+	res := make(map[string][]UnitPortRange, len(p.ByEndpoint_))
+	for endpointName, portRanges := range p.ByEndpoint_ {
+		rangeList := make([]UnitPortRange, len(portRanges))
+		for i, portRange := range portRanges {
+			rangeList[i] = portRange
+		}
+		res[endpointName] = rangeList
+	}
+	return res
+}
+
+type unitPortRange struct {
+	FromPort_ int    `yaml:"from-port"`
+	ToPort_   int    `yaml:"to-port"`
+	Protocol_ string `yaml:"protocol"`
+}
+
+func newUnitPortRange(fromPort, toPort int, protocol string) *unitPortRange {
+	return &unitPortRange{
+		FromPort_: fromPort,
+		ToPort_:   toPort,
+		Protocol_: protocol,
+	}
+}
+
+// FromPort implements UnitPortRange.
+func (p unitPortRange) FromPort() int {
+	return p.FromPort_
+}
+
+// ToPort implements UnitPortRange.
+func (p unitPortRange) ToPort() int {
+	return p.ToPort_
+}
+
+// Protocol implements UnitPortRange.
+func (p unitPortRange) Protocol() string {
+	return p.Protocol_
+}
+
+func importMachinePortRanges(source map[string]interface{}) (*machinePortRanges, error) {
+	checker := versionedMapChecker("machine-port-ranges")
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "machine-port-ranges version schema check failed")
+	}
+	valid := coerced.(map[string]interface{})
+
+	version := int(valid["version"].(int64))
+	importFunc, ok := machinePortRangeDeserializationFuncs[version]
+	if !ok {
+		return nil, errors.NotValidf("version %d", version)
+	}
+	sourceMap := valid["machine-port-ranges"].(map[string]interface{})
+	return importFunc(sourceMap)
+}
+
+type machinePortRangeDeserializationFunc func(map[string]interface{}) (*machinePortRanges, error)
+
+var machinePortRangeDeserializationFuncs = map[int]machinePortRangeDeserializationFunc{
+	1: importMachinePortRangeV1,
+}
+
+func importMachinePortRangeV1(source map[string]interface{}) (*machinePortRanges, error) {
+	unitChecker := schema.FieldMap(schema.Fields{
+		"unit-port-ranges": schema.StringMap(
+			schema.List(schema.StringMap(schema.Any())),
+		),
+	}, nil) // no defaults
+
+	portRangeChecker := schema.FieldMap(schema.Fields{
+		"from-port": schema.Int(),
+		"to-port":   schema.Int(),
+		"protocol":  schema.String(),
+	}, nil) // no defaults
+
+	mpr := &machinePortRanges{
+		Version: 1,
+		ByUnit_: make(map[string]*unitPortRanges),
+	}
+	for unitName, unitSource := range source {
+		coercedUnit, err := unitChecker.Coerce(unitSource, nil)
+		if err != nil {
+			return nil, errors.Annotatef(err, "machine-port-range v1 schema check failed")
+		}
+
+		validFieldMap := coercedUnit.(map[string]interface{})
+		validEndpointMap := validFieldMap["unit-port-ranges"].(map[string]interface{})
+		upr := &unitPortRanges{
+			ByEndpoint_: make(map[string][]*unitPortRange),
+		}
+		for endpointName, portRangeListSource := range validEndpointMap {
+			validPortRangeListSource := portRangeListSource.([]interface{})
+			portRangeList := make([]*unitPortRange, len(validPortRangeListSource))
+			for i, portRangeSource := range validPortRangeListSource {
+				validPortRangeSource := portRangeSource.(map[string]interface{})
+				pr, err := importUnitPortRangeV1(validPortRangeSource, portRangeChecker)
+				if err != nil {
+					return nil, errors.Annotatef(err, "unable to parse V1 unit port range")
+				}
+				portRangeList[i] = pr
+			}
+			upr.ByEndpoint_[endpointName] = portRangeList
+		}
+
+		mpr.ByUnit_[unitName] = upr
+	}
+
+	return mpr, nil
+}
+
+func importUnitPortRangeV1(source map[string]interface{}, checker schema.Checker) (*unitPortRange, error) {
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "unit-port-range v1 schema check failed")
+	}
+
+	valid := coerced.(map[string]interface{})
+	return &unitPortRange{
+		FromPort_: int(valid["from-port"].(int64)),
+		ToPort_:   int(valid["to-port"].(int64)),
+		Protocol_: valid["protocol"].(string),
+	}, nil
+}

--- a/port_ranges_test.go
+++ b/port_ranges_test.go
@@ -12,6 +12,12 @@ import (
 type MachinePortRangeSerializationSuite struct {
 }
 
+func assertUnitPortRangeMatches(c *gc.C, prA, prB UnitPortRange) {
+	c.Assert(prA.FromPort(), gc.Equals, prB.FromPort())
+	c.Assert(prA.ToPort(), gc.Equals, prB.ToPort())
+	c.Assert(prA.Protocol(), gc.Equals, prB.Protocol())
+}
+
 var _ = gc.Suite(&MachinePortRangeSerializationSuite{})
 
 func (*MachinePortRangeSerializationSuite) TestParsingSerializedData(c *gc.C) {

--- a/port_ranges_test.go
+++ b/port_ranges_test.go
@@ -1,0 +1,66 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package description
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
+)
+
+type MachinePortRangeSerializationSuite struct {
+}
+
+var _ = gc.Suite(&MachinePortRangeSerializationSuite{})
+
+func (*MachinePortRangeSerializationSuite) TestParsingSerializedData(c *gc.C) {
+	initial := &machinePortRanges{
+		Version: 1,
+		ByUnit_: map[string]*unitPortRanges{
+			"lorem/0": &unitPortRanges{
+				ByEndpoint_: map[string][]*unitPortRange{
+					"dmz": []*unitPortRange{
+						newUnitPortRange(1234, 2345, "tcp"),
+						newUnitPortRange(1337, 1337, "udp"),
+					},
+				},
+			},
+			"ipsum/0": &unitPortRanges{
+				ByEndpoint_: map[string][]*unitPortRange{
+					"": []*unitPortRange{
+						newUnitPortRange(8080, 8080, "tcp"),
+					},
+				},
+			},
+		},
+	}
+
+	bytes, err := yaml.Marshal(initial)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var source map[string]interface{}
+	err = yaml.Unmarshal(bytes, &source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	imported, err := importMachinePortRanges(source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	byUnit := imported.ByUnit()
+	c.Assert(byUnit, gc.HasLen, 2)
+
+	// Check lorem/0 ports
+	loremPortsByEndpoint := byUnit["lorem/0"].ByEndpoint()
+	c.Assert(loremPortsByEndpoint, gc.HasLen, 1)
+	loremDMZPorts := loremPortsByEndpoint["dmz"]
+	c.Assert(loremDMZPorts, gc.HasLen, 2)
+	c.Assert(loremDMZPorts[0], gc.DeepEquals, newUnitPortRange(1234, 2345, "tcp"))
+	c.Assert(loremDMZPorts[1], gc.DeepEquals, newUnitPortRange(1337, 1337, "udp"))
+
+	// Check ipsum/0 ports
+	ipsumPortsByEndpoint := byUnit["ipsum/0"].ByEndpoint()
+	c.Assert(ipsumPortsByEndpoint, gc.HasLen, 1)
+	ipsumAllEndpointPorts := ipsumPortsByEndpoint[""]
+	c.Assert(ipsumAllEndpointPorts, gc.HasLen, 1)
+	c.Assert(ipsumAllEndpointPorts[0], gc.DeepEquals, newUnitPortRange(8080, 8080, "tcp"))
+}

--- a/ports.go
+++ b/ports.go
@@ -10,6 +10,9 @@ import (
 
 // OpenedPorts represents a collection of port ranges that are open on a
 // particular subnet. OpenedPorts are always associated with a Machine.
+//
+// This type is deprecated and retained for backwards-compatibility purposes.
+// The MachinePortRanges interface should be used instead.
 type OpenedPorts interface {
 	SubnetID() string
 	OpenPorts() []PortRange
@@ -17,6 +20,9 @@ type OpenedPorts interface {
 
 // PortRange represents one or more contiguous ports opened by a particular
 // Unit.
+//
+// This type is deprecated and retained for backwards-compatibility purposes.
+// The UnitPortRange interface should be used instead.
 type PortRange interface {
 	UnitName() string
 	FromPort() int

--- a/serialization.go
+++ b/serialization.go
@@ -20,6 +20,16 @@ func versionedChecker(name string) schema.Checker {
 	return schema.FieldMap(fields, nil) // no defaults
 }
 
+func versionedMapChecker(name string) schema.Checker {
+	fields := schema.Fields{
+		"version": schema.Int(),
+	}
+	if name != "" {
+		fields[name] = schema.StringMap(schema.Any())
+	}
+	return schema.FieldMap(fields, nil) // no defaults
+}
+
 func versionedEmbeddedChecker(name string) schema.Checker {
 	fields := schema.Fields{
 		"version": schema.Int(),


### PR DESCRIPTION
This PR is part of the work for allowing juju to open/close machine ports in an endpoint-aware manner. To this end, juju must be able to accurately describe the set of opened port ranges for a machine by linking each opened port range with the set of endpoints that the range is exposed to.

The `Machine` type already includes information about port ranges but this information is associated with subnet IDs instead of endpoints. As the type could not be augmented to include the required information, this PR introduces a few new interfaces (`MachinePortRanges`, `UnitPortRanges` and `UnitPortRange`) and flags the old Port types as deprecated.

The new types require a new version (V2) for the type that describes machines. The `Machine` type now only exposes the new interfaces for port ranges. To maintain backwards compatibility, the V1 parsing code will transparently convert the legacy port range values into the new format by exploiting the observation that pre 2.9 controllers never used the multi-subnet functionality of the opened ports documents but instead assumed that all ports are opened to **all** subnets (in other words, the legacy port range lists only include a single document with an **empty** `SubnetID`). Consequently, we can simply convert the old port ranges as if they are exposed for **all** endpoints (signified by an empty endpoint name).

Finally, as a drive-by fix, the PR changes the model validation code so that mutable maps are not passed by value across methods.
