### PR TITLE
Add application fields for tracking expose parameters

### DIFF
--- a/model.go
+++ b/model.go
@@ -442,7 +442,7 @@ func (m *model) AddApplication(args ApplicationArgs) Application {
 
 func (m *model) setApplications(applicationList []*application) {
 	m.Applications_ = applications{
-		Version:       7,
+		Version:       8,
 		Applications_: applicationList,
 	}
 }


### PR DESCRIPTION
This PR augments the description for applications with new fields that keep track of:
- the exposed application endpoints (if any)
- the list of space IDs (if any) that should be able to access the application
- the list of CIDRs (if any) that should be able to access the application