### PR TITLE
CharmOrigin architecture

### DIFF
--- a/charmorigin.go
+++ b/charmorigin.go
@@ -16,6 +16,7 @@ type CharmOriginArgs struct {
 	Hash     string
 	Revision int
 	Channel  string
+	Arch     string
 }
 
 func newCharmOrigin(args CharmOriginArgs) *charmOrigin {
@@ -26,6 +27,7 @@ func newCharmOrigin(args CharmOriginArgs) *charmOrigin {
 		Hash_:     args.Hash,
 		Revision_: args.Revision,
 		Channel_:  args.Channel,
+		Arch_:     args.Arch,
 	}
 }
 
@@ -39,6 +41,7 @@ type charmOrigin struct {
 	Hash_     string `yaml:"hash"`
 	Revision_ int    `yaml:"revision"`
 	Channel_  string `yaml:"channel"`
+	Arch_     string `yaml:"arch"`
 }
 
 // Source implements CharmOrigin.
@@ -64,6 +67,11 @@ func (a *charmOrigin) Revision() int {
 // Channel implements CharmOrigin.
 func (a *charmOrigin) Channel() string {
 	return a.Channel_
+}
+
+// Arch implements CharmOrigin.
+func (a *charmOrigin) Arch() string {
+	return a.Arch_
 }
 
 func importCharmOrigin(source map[string]interface{}) (*charmOrigin, error) {
@@ -93,6 +101,7 @@ func importCharmOriginV1(source map[string]interface{}) (*charmOrigin, error) {
 		"hash":     schema.String(),
 		"revision": schema.Int(),
 		"channel":  schema.String(),
+		"arch":     schema.String(),
 	}
 	defaults := schema.Defaults{
 		"source":   "unknown",
@@ -100,6 +109,7 @@ func importCharmOriginV1(source map[string]interface{}) (*charmOrigin, error) {
 		"hash":     schema.Omit,
 		"revision": schema.Omit,
 		"channel":  schema.Omit,
+		"arch":     schema.Omit,
 	}
 	checker := schema.FieldMap(fields, defaults)
 
@@ -129,5 +139,6 @@ func importCharmOriginV1(source map[string]interface{}) (*charmOrigin, error) {
 		Hash_:     valid["hash"].(string),
 		Revision_: revision,
 		Channel_:  valid["channel"].(string),
+		Arch_:     valid["arch"].(string),
 	}, nil
 }

--- a/charmorigin_test.go
+++ b/charmorigin_test.go
@@ -39,6 +39,7 @@ func minimalCharmOriginMap() map[interface{}]interface{} {
 		"hash":     "",
 		"revision": 0,
 		"channel":  "",
+		"arch":     "",
 	}
 }
 
@@ -60,6 +61,7 @@ func maximalCharmOriginMap() map[interface{}]interface{} {
 		"hash":     "c553eee8dc77f2cce29a1c7090d1e3c81e76c6e12346d09936048ed12305fd35",
 		"revision": 0,
 		"channel":  "foo/stable",
+		"arch":     "amd64",
 	}
 }
 
@@ -69,6 +71,7 @@ func maximalCharmOriginArgs() CharmOriginArgs {
 		ID:      "random-id",
 		Hash:    "c553eee8dc77f2cce29a1c7090d1e3c81e76c6e12346d09936048ed12305fd35",
 		Channel: "foo/stable",
+		Arch:    "amd64",
 	}
 }
 

--- a/interfaces.go
+++ b/interfaces.go
@@ -232,4 +232,5 @@ type CharmOrigin interface {
 	Hash() string
 	Revision() int
 	Channel() string
+	Arch() string
 }


### PR DESCRIPTION
CharmOrigin should also hold the architecture of a given charm origin.
That way we can identify a charm for a revision for a given
architecture. This will help with understanding the multiple
architecture requirement.