### PR TITLE
Rename arch to platform

### DIFF
--- a/charmorigin.go
+++ b/charmorigin.go
@@ -16,7 +16,7 @@ type CharmOriginArgs struct {
 	Hash     string
 	Revision int
 	Channel  string
-	Arch     string
+	Platform string
 }
 
 func newCharmOrigin(args CharmOriginArgs) *charmOrigin {
@@ -27,7 +27,7 @@ func newCharmOrigin(args CharmOriginArgs) *charmOrigin {
 		Hash_:     args.Hash,
 		Revision_: args.Revision,
 		Channel_:  args.Channel,
-		Arch_:     args.Arch,
+		Platform_: args.Platform,
 	}
 }
 
@@ -41,7 +41,7 @@ type charmOrigin struct {
 	Hash_     string `yaml:"hash"`
 	Revision_ int    `yaml:"revision"`
 	Channel_  string `yaml:"channel"`
-	Arch_     string `yaml:"arch"`
+	Platform_ string `yaml:"platform"`
 }
 
 // Source implements CharmOrigin.
@@ -69,9 +69,9 @@ func (a *charmOrigin) Channel() string {
 	return a.Channel_
 }
 
-// Arch implements CharmOrigin.
-func (a *charmOrigin) Arch() string {
-	return a.Arch_
+// Platform implements CharmOrigin.
+func (a *charmOrigin) Platform() string {
+	return a.Platform_
 }
 
 func importCharmOrigin(source map[string]interface{}) (*charmOrigin, error) {
@@ -101,7 +101,7 @@ func importCharmOriginV1(source map[string]interface{}) (*charmOrigin, error) {
 		"hash":     schema.String(),
 		"revision": schema.Int(),
 		"channel":  schema.String(),
-		"arch":     schema.String(),
+		"platform": schema.String(),
 	}
 	defaults := schema.Defaults{
 		"source":   "unknown",
@@ -109,7 +109,7 @@ func importCharmOriginV1(source map[string]interface{}) (*charmOrigin, error) {
 		"hash":     schema.Omit,
 		"revision": schema.Omit,
 		"channel":  schema.Omit,
-		"arch":     schema.Omit,
+		"platform": schema.Omit,
 	}
 	checker := schema.FieldMap(fields, defaults)
 
@@ -139,6 +139,6 @@ func importCharmOriginV1(source map[string]interface{}) (*charmOrigin, error) {
 		Hash_:     valid["hash"].(string),
 		Revision_: revision,
 		Channel_:  valid["channel"].(string),
-		Arch_:     valid["arch"].(string),
+		Platform_: valid["platform"].(string),
 	}, nil
 }

--- a/charmorigin_test.go
+++ b/charmorigin_test.go
@@ -39,7 +39,7 @@ func minimalCharmOriginMap() map[interface{}]interface{} {
 		"hash":     "",
 		"revision": 0,
 		"channel":  "",
-		"arch":     "",
+		"platform": "",
 	}
 }
 
@@ -61,17 +61,17 @@ func maximalCharmOriginMap() map[interface{}]interface{} {
 		"hash":     "c553eee8dc77f2cce29a1c7090d1e3c81e76c6e12346d09936048ed12305fd35",
 		"revision": 0,
 		"channel":  "foo/stable",
-		"arch":     "amd64",
+		"platform": "ubuntu/focal/amd64",
 	}
 }
 
 func maximalCharmOriginArgs() CharmOriginArgs {
 	return CharmOriginArgs{
-		Source:  "charmhub",
-		ID:      "random-id",
-		Hash:    "c553eee8dc77f2cce29a1c7090d1e3c81e76c6e12346d09936048ed12305fd35",
-		Channel: "foo/stable",
-		Arch:    "amd64",
+		Source:   "charmhub",
+		ID:       "random-id",
+		Hash:     "c553eee8dc77f2cce29a1c7090d1e3c81e76c6e12346d09936048ed12305fd35",
+		Channel:  "foo/stable",
+		Platform: "ubuntu/focal/amd64",
 	}
 }
 

--- a/interfaces.go
+++ b/interfaces.go
@@ -233,5 +233,5 @@ type CharmOrigin interface {
 	Hash() string
 	Revision() int
 	Channel() string
-	Arch() string
+	Platform() string
 }


### PR DESCRIPTION
To allow us to model the architecture and the os as one thing in an
origin, we should encapsulate everything.

Arch is now platform modelled as `os/series/architecture`