### PR TITLE
[JUJU-390] Add DisplayName to the Machine description

### DIFF
--- a/cloudinstance_test.go
+++ b/cloudinstance_test.go
@@ -162,6 +162,7 @@ func (s *CloudInstanceSerializationSuite) testArgs() CloudInstanceArgs {
 	// NOTE: using gig from package_test.go
 	return CloudInstanceArgs{
 		InstanceId:       "instance id",
+		DisplayName:      "foo",
 		Architecture:     "amd64",
 		Memory:           16 * gig,
 		RootDisk:         200 * gig,
@@ -185,6 +186,7 @@ func (s *CloudInstanceSerializationSuite) allV4Map() map[string]interface{} {
 	return map[string]interface{}{
 		"version":             4,
 		"instance-id":         "instance id",
+		"display-name":        "foo",
 		"status":              minimalStatusMap(),
 		"status-history":      emptyStatusHistoryMap(),
 		"modification-status": minimalStatusMap(),
@@ -235,6 +237,7 @@ func (s *CloudInstanceSerializationSuite) allV5Map() map[string]interface{} {
 	return map[string]interface{}{
 		"version":             5,
 		"instance-id":         "instance id",
+		"display-name":        "foo",
 		"status":              minimalStatusMap(),
 		"status-history":      emptyStatusHistoryMap(),
 		"modification-status": minimalStatusMap(),

--- a/machine.go
+++ b/machine.go
@@ -28,8 +28,6 @@ type Machine interface {
 	Jobs() []string
 	SupportedContainers() ([]string, bool)
 
-	DisplayName() string
-
 	Instance() CloudInstance
 	SetInstance(CloudInstanceArgs)
 
@@ -65,7 +63,6 @@ type machines struct {
 type machine struct {
 	Id_            string         `yaml:"id"`
 	Nonce_         string         `yaml:"nonce"`
-	DisplayName_   string         `yaml:"display-name,omitempty"`
 	PasswordHash_  string         `yaml:"password-hash"`
 	Placement_     string         `yaml:"placement,omitempty"`
 	Instance_      *cloudInstance `yaml:"instance,omitempty"`
@@ -109,7 +106,6 @@ type MachineArgs struct {
 	// A null value means that we don't yet know which containers
 	// are supported. An empty slice means 'no containers are supported'.
 	SupportedContainers *[]string
-	DisplayName         string
 }
 
 func newMachine(args MachineArgs) *machine {
@@ -121,7 +117,6 @@ func newMachine(args MachineArgs) *machine {
 	m := &machine{
 		Id_:            args.Id.Id(),
 		Nonce_:         args.Nonce,
-		DisplayName_:   args.DisplayName,
 		PasswordHash_:  args.PasswordHash,
 		Placement_:     args.Placement,
 		Series_:        args.Series,
@@ -151,11 +146,6 @@ func (m *machine) Tag() names.MachineTag {
 // Nonce implements Machine.
 func (m *machine) Nonce() string {
 	return m.Nonce_
-}
-
-// DisplayName implements Machine.
-func (m *machine) DisplayName() string {
-	return m.DisplayName_
 }
 
 // PasswordHash implements Machine.
@@ -479,10 +469,6 @@ func machineV1(valid map[string]interface{}) (*machine, error) {
 		return nil, errors.Trace(err)
 	}
 
-	if displayName, ok := valid["display-name"].(string); ok {
-		result.DisplayName_ = displayName
-	}
-
 	if constraintsMap, ok := valid["constraints"]; ok {
 		constraints, err := importConstraints(constraintsMap.(map[string]interface{}))
 		if err != nil {
@@ -625,7 +611,6 @@ func machineSchemaV1() (schema.Fields, schema.Defaults) {
 	fields := schema.Fields{
 		"id":                   schema.String(),
 		"nonce":                schema.String(),
-		"display-name":         schema.String(),
 		"password-hash":        schema.String(),
 		"placement":            schema.String(),
 		"instance":             schema.StringMap(schema.Any()),
@@ -651,7 +636,6 @@ func machineSchemaV1() (schema.Fields, schema.Defaults) {
 		"container-type": "",
 		// Even though we are expecting instance data for every machine,
 		// it isn't strictly necessary, so we allow it to not exist here.
-		"display-name":              schema.Omit,
 		"instance":                  schema.Omit,
 		"supported-containers":      schema.Omit,
 		"opened-ports":              schema.Omit,


### PR DESCRIPTION
This adds the `DisplayName` field for a machine to transfer its display name through the migration. 

It is a pre-requisite for this PR on juju for fixing the [LP #1954969](https://bugs.launchpad.net/juju/+bug/1954969).

#### QA steps

Added the `display-name` field in the unit tests within the `cloudinstance_test.go`, so the following should succeed.

```sh
  $ go test
```



