### PR TITLE
Charm origin platform now uses channel

### DIFF
--- a/application_test.go
+++ b/application_test.go
@@ -38,7 +38,6 @@ func (s *ApplicationSerializationSuite) SetUpTest(c *gc.C) {
 func minimalApplicationMap() map[interface{}]interface{} {
 	return map[interface{}]interface{}{
 		"name":              "ubuntu",
-		"series":            "trusty",
 		"type":              IAAS,
 		"charm-url":         "cs:trusty/ubuntu",
 		"cs-channel":        "stable",
@@ -164,7 +163,6 @@ func addMinimalApplication(model Model) {
 func minimalApplicationArgs(modelType string) ApplicationArgs {
 	result := ApplicationArgs{
 		Tag:                  names.NewApplicationTag("ubuntu"),
-		Series:               "trusty",
 		Type:                 modelType,
 		CharmURL:             "cs:trusty/ubuntu",
 		Channel:              "stable",
@@ -198,9 +196,8 @@ func minimalApplicationArgs(modelType string) ApplicationArgs {
 func (s *ApplicationSerializationSuite) TestNewApplication(c *gc.C) {
 	args := ApplicationArgs{
 		Tag:                  names.NewApplicationTag("magic"),
-		Series:               "zesty",
 		Subordinate:          true,
-		CharmURL:             "cs:zesty/magic",
+		CharmURL:             "cs:jammy/magic",
 		Channel:              "stable",
 		CharmModifiedVersion: 1,
 		ForceCharm:           true,
@@ -238,9 +235,8 @@ func (s *ApplicationSerializationSuite) TestNewApplication(c *gc.C) {
 
 	c.Assert(application.Name(), gc.Equals, "magic")
 	c.Assert(application.Tag(), gc.Equals, names.NewApplicationTag("magic"))
-	c.Assert(application.Series(), gc.Equals, "zesty")
 	c.Assert(application.Subordinate(), jc.IsTrue)
-	c.Assert(application.CharmURL(), gc.Equals, "cs:zesty/magic")
+	c.Assert(application.CharmURL(), gc.Equals, "cs:jammy/magic")
 	c.Assert(application.Channel(), gc.Equals, "stable")
 	c.Assert(application.CharmModifiedVersion(), gc.Equals, 1)
 	c.Assert(application.ForceCharm(), jc.IsTrue)
@@ -340,12 +336,13 @@ func (s *ApplicationSerializationSuite) exportImportVersion(c *gc.C, application
 }
 
 func (s *ApplicationSerializationSuite) exportImportLatest(c *gc.C, application_ *application) *application {
-	return s.exportImportVersion(c, application_, 8)
+	return s.exportImportVersion(c, application_, 9)
 }
 
 func (s *ApplicationSerializationSuite) TestV1ParsingReturnsLatest(c *gc.C) {
 	args := minimalApplicationArgs(CAAS)
 	args.Type = ""
+	args.Series = "focal"
 	appV1 := minimalApplication(args)
 
 	// Make an app with fields not in v1 removed.
@@ -362,11 +359,13 @@ func (s *ApplicationSerializationSuite) TestV1ParsingReturnsLatest(c *gc.C) {
 	appLatest.CharmOrigin_ = nil
 
 	appResult := s.exportImportVersion(c, appV1, 1)
+	appLatest.Series_ = ""
 	c.Assert(appResult, jc.DeepEquals, appLatest)
 }
 
 func (s *ApplicationSerializationSuite) TestV2ParsingReturnsLatest(c *gc.C) {
 	args := minimalApplicationArgs(CAAS)
+	args.Series = "focal"
 	appV1 := minimalApplication(args)
 
 	// Make an app with fields not in v2 removed.
@@ -383,11 +382,13 @@ func (s *ApplicationSerializationSuite) TestV2ParsingReturnsLatest(c *gc.C) {
 	appLatest.CharmOrigin_ = nil
 
 	appResult := s.exportImportVersion(c, appV1, 2)
+	appLatest.Series_ = ""
 	c.Assert(appResult, jc.DeepEquals, appLatest)
 }
 
 func (s *ApplicationSerializationSuite) TestV3ParsingReturnsLatest(c *gc.C) {
 	args := minimalApplicationArgs(CAAS)
+	args.Series = "focal"
 	appV2 := minimalApplication(args)
 
 	// Make an app with fields not in v3 removed.
@@ -400,11 +401,13 @@ func (s *ApplicationSerializationSuite) TestV3ParsingReturnsLatest(c *gc.C) {
 	appLatest.CharmOrigin_ = nil
 
 	appResult := s.exportImportVersion(c, appV2, 3)
+	appLatest.Series_ = ""
 	c.Assert(appResult, jc.DeepEquals, appLatest)
 }
 
 func (s *ApplicationSerializationSuite) TestV5ParsingReturnsLatest(c *gc.C) {
 	args := minimalApplicationArgs(CAAS)
+	args.Series = "focal"
 	appV5 := minimalApplication(args)
 
 	// Make an app with fields not in v5 removed.
@@ -413,11 +416,13 @@ func (s *ApplicationSerializationSuite) TestV5ParsingReturnsLatest(c *gc.C) {
 	appLatest.CharmOrigin_ = nil
 
 	appResult := s.exportImportVersion(c, appV5, 5)
+	appLatest.Series_ = ""
 	c.Assert(appResult, jc.DeepEquals, appLatest)
 }
 
 func (s *ApplicationSerializationSuite) TestV6ParsingReturnsLatest(c *gc.C) {
 	args := minimalApplicationArgs(CAAS)
+	args.Series = "focal"
 	appV6 := minimalApplication(args)
 
 	// Make an app with fields not in v6 removed.
@@ -425,6 +430,7 @@ func (s *ApplicationSerializationSuite) TestV6ParsingReturnsLatest(c *gc.C) {
 	appLatest.CharmOrigin_ = nil
 
 	appResult := s.exportImportVersion(c, appV6, 6)
+	appLatest.Series_ = ""
 	c.Assert(appResult, jc.DeepEquals, appLatest)
 }
 
@@ -592,7 +598,7 @@ func (s *ApplicationSerializationSuite) TestIAASUnitMissingTools(c *gc.C) {
 	app := minimalApplication()
 	app.Units_.Units_[0].Tools_ = nil
 	initial := applications{
-		Version:       3,
+		Version:       9,
 		Applications_: []*application{app},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/juju/collections v1.0.0
 	github.com/juju/errors v1.0.0
 	github.com/juju/names/v4 v4.0.0
+	github.com/juju/os/v2 v2.2.3
 	github.com/juju/schema v1.0.1
 	github.com/juju/testing v1.0.2
 	github.com/juju/version/v2 v2.0.1
@@ -24,4 +25,5 @@ require (
 	github.com/rogpeppe/go-internal v1.8.1 // indirect
 	golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3 // indirect
 	golang.org/x/net v0.0.0-20211216030914-fe4d6282115f // indirect
+	golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/golang/mock v1.5.0 h1:jlYHihg//f7RRwuPfptm04yp4s7O6Kw8EZiVYIGcH0g=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
 github.com/juju/clock v1.0.0 h1:9U1jPr/FT0DfZjl8qh9dSACAXUodjPOz+uZBdeVv/N8=
 github.com/juju/clock v1.0.0/go.mod h1:GZ/FY8Cqw3KHG6DwRVPUKbSPTAwyrU28xFi5cqZnLsc=
@@ -12,6 +13,8 @@ github.com/juju/mgo/v3 v3.0.2 h1:I2F9bfxhlydulZhtTSYm+r0k6T3SDkgs4oJZ3TCTnTY=
 github.com/juju/mgo/v3 v3.0.2/go.mod h1:fAvhDCRbUlEbRIae6UQT8RvPUoLwKnJsBgO6OzHKNxw=
 github.com/juju/names/v4 v4.0.0 h1:XeQZbwT70i98TynM+2RJr9At6EGb9X/P6l8qF56hPns=
 github.com/juju/names/v4 v4.0.0/go.mod h1:xpkrQpHbz1DGY+0Geo32ZnyognGA/2vSB++rpu/Z+Lc=
+github.com/juju/os/v2 v2.2.3 h1:5SnGWfzFTXcFwu/sd9qEEf/No3UZxivOjJuWmsHI4N4=
+github.com/juju/os/v2 v2.2.3/go.mod h1:xGfP9I+Xb/A03NcGBsoJgwr084hPckkQHecaHuV3wBQ=
 github.com/juju/schema v1.0.1 h1:GBEiwxZQeoQuXI6gOTG58W/ZpdongMwl9pfZq1KcNgM=
 github.com/juju/schema v1.0.1/go.mod h1:Y+ThzXpUJ0E7NYYocAbuvJ7vTivXfrof/IfRPq/0abI=
 github.com/juju/testing v1.0.2 h1:OR90RqCd9CJONxXamZAjLknpZdtqDyxqW8IwCbgw3i4=
@@ -41,6 +44,8 @@ golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3 h1:0es+/5331RGQPcXlMfP+Wr
 golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/net v0.0.0-20211216030914-fe4d6282115f h1:hEYJvxw1lSnWIl8X9ofsYMklzaDs90JI2az5YMd4fPM=
 golang.org/x/net v0.0.0-20211216030914-fe4d6282115f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069 h1:siQdpVirKtzPhKl3lZWozZraCFObP8S1v6PRp0bLrtU=
+golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20160105164936-4f90aeace3a2/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/model.go
+++ b/model.go
@@ -448,7 +448,7 @@ func (m *model) AddApplication(args ApplicationArgs) Application {
 
 func (m *model) setApplications(applicationList []*application) {
 	m.Applications_ = applications{
-		Version:       8,
+		Version:       9,
 		Applications_: applicationList,
 	}
 }


### PR DESCRIPTION
Previously, charm origin platform encoded the series name in the string value
eg "amd64/ubuntu/focal".

We now instead use the os version.
eg "amd64/ubuntu/20.04/stable"