### PR TITLE
Remove series from image metadata

### DIFF
--- a/cloudimagemetadata_test.go
+++ b/cloudimagemetadata_test.go
@@ -22,7 +22,7 @@ func (s *CloudImageMetadataSerializationSuite) SetUpTest(c *gc.C) {
 	s.importName = "cloudimagemetadata"
 	s.sliceName = "cloudimagemetadata"
 	s.importFunc = func(m map[string]interface{}) (interface{}, error) {
-		return importCloudImageMetadata(m)
+		return importCloudImageMetadatas(m)
 	}
 	s.testFields = func(m map[string]interface{}) {
 		m["cloudimagemetadata"] = []interface{}{}
@@ -36,7 +36,6 @@ func (s *CloudImageMetadataSerializationSuite) TestNewCloudImageMetadata(c *gc.C
 		Stream:          "stream",
 		Region:          "region-test",
 		Version:         "14.04",
-		Series:          "trusty",
 		Arch:            "arch",
 		VirtType:        "virtType-test",
 		RootStorageType: "rootStorageType-test",
@@ -51,7 +50,6 @@ func (s *CloudImageMetadataSerializationSuite) TestNewCloudImageMetadata(c *gc.C
 	c.Check(metadata.Stream(), gc.Equals, args.Stream)
 	c.Check(metadata.Region(), gc.Equals, args.Region)
 	c.Check(metadata.Version(), gc.Equals, args.Version)
-	c.Check(metadata.Series(), gc.Equals, args.Series)
 	c.Check(metadata.Arch(), gc.Equals, args.Arch)
 	c.Check(metadata.VirtType(), gc.Equals, args.VirtType)
 	c.Check(metadata.RootStorageType(), gc.Equals, args.RootStorageType)
@@ -69,13 +67,12 @@ func (s *CloudImageMetadataSerializationSuite) TestParsingSerializedData(c *gc.C
 	storageSize := uint64(3)
 	now := time.Now()
 	initial := cloudimagemetadataset{
-		Version: 1,
+		Version: 2,
 		CloudImageMetadata_: []*cloudimagemetadata{
 			newCloudImageMetadata(CloudImageMetadataArgs{
 				Stream:          "stream",
 				Region:          "region-test",
 				Version:         "14.04",
-				Series:          "trusty",
 				Arch:            "arch",
 				VirtType:        "virtType-test",
 				RootStorageType: "rootStorageType-test",
@@ -101,7 +98,7 @@ func (s *CloudImageMetadataSerializationSuite) TestParsingSerializedData(c *gc.C
 	err = yaml.Unmarshal(bytes, &source)
 	c.Assert(err, jc.ErrorIsNil)
 
-	metadata, err := importCloudImageMetadata(source)
+	metadata, err := importCloudImageMetadatas(source)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(metadata, jc.DeepEquals, initial.CloudImageMetadata_)

--- a/interfaces.go
+++ b/interfaces.go
@@ -71,7 +71,6 @@ type CloudImageMetadata interface {
 	Stream() string
 	Region() string
 	Version() string
-	Series() string
 	Arch() string
 	VirtType() string
 	RootStorageType() string

--- a/model.go
+++ b/model.go
@@ -666,14 +666,14 @@ func (m *model) Operations() []Operation {
 
 // AddCloudImageMetadata implements Model.
 func (m *model) AddCloudImageMetadata(args CloudImageMetadataArgs) CloudImageMetadata {
-	addr := newCloudImageMetadata(args)
-	m.CloudImageMetadata_.CloudImageMetadata_ = append(m.CloudImageMetadata_.CloudImageMetadata_, addr)
-	return addr
+	md := newCloudImageMetadata(args)
+	m.CloudImageMetadata_.CloudImageMetadata_ = append(m.CloudImageMetadata_.CloudImageMetadata_, md)
+	return md
 }
 
 func (m *model) setCloudImageMetadatas(cloudimagemetadataList []*cloudimagemetadata) {
 	m.CloudImageMetadata_ = cloudimagemetadataset{
-		Version:             1,
+		Version:             2,
 		CloudImageMetadata_: cloudimagemetadataList,
 	}
 }
@@ -1635,7 +1635,7 @@ func newModelFromValid(valid map[string]interface{}, importVersion int) (*model,
 	result.setSSHHostKeys(hostKeys)
 
 	cloudimagemetadataMap := valid["cloud-image-metadata"].(map[string]interface{})
-	cloudimagemetadata, err := importCloudImageMetadata(cloudimagemetadataMap)
+	cloudimagemetadata, err := importCloudImageMetadatas(cloudimagemetadataMap)
 	if err != nil {
 		return nil, errors.Annotate(err, "cloud-image-metadata")
 	}

--- a/model_test.go
+++ b/model_test.go
@@ -1250,7 +1250,6 @@ func (s *ModelSerializationSuite) TestCloudImageMetadata(c *gc.C) {
 		Stream:          "stream",
 		Region:          "region-test",
 		Version:         "14.04",
-		Series:          "trusty",
 		Arch:            "arch",
 		VirtType:        "virtType-test",
 		RootStorageType: "rootStorageType-test",


### PR DESCRIPTION
Remove series from cloud image metadata. It is not used by juju for anything meaningful, and we have version (we only cache ubuntu image metadata).