### PR TITLE
Fixes bug with series to platform upgrades.

### DIFF
--- a/application.go
+++ b/application.go
@@ -824,13 +824,18 @@ func importApplication(fields schema.Fields, defaults schema.Defaults, importVer
 	}
 
 	series, hasSeries := valid["series"].(string)
-	if importVersion <= 9 && importVersion >= 7 && hasSeries {
-		// If we have a series but no platform defined lets make a platform from the series
-		if result.CharmOrigin_ != nil && result.CharmOrigin_.Platform_ == "" {
-			platform, err := platformFromSeries(series)
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
+	// If we have a series but no platform defined lets make a platform from the series
+	if hasSeries && (result.CharmOrigin_ == nil || result.CharmOrigin_.Platform_ == "") {
+		platform, err := platformFromSeries(series)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+
+		if result.CharmOrigin_ == nil {
+			result.CharmOrigin_ = newCharmOrigin(CharmOriginArgs{
+				Platform: platform,
+			})
+		} else {
 			result.CharmOrigin_.Platform_ = platform
 		}
 	}

--- a/application_test.go
+++ b/application_test.go
@@ -356,7 +356,9 @@ func (s *ApplicationSerializationSuite) TestV1ParsingReturnsLatest(c *gc.C) {
 	appLatest.Tools_ = nil
 	appLatest.OperatorStatus_ = nil
 	appLatest.Offers_ = nil
-	appLatest.CharmOrigin_ = nil
+	appLatest.CharmOrigin_ = newCharmOrigin(CharmOriginArgs{
+		Platform: "unknown/ubuntu/20.04",
+	})
 
 	appResult := s.exportImportVersion(c, appV1, 1)
 	appLatest.Series_ = ""
@@ -379,7 +381,9 @@ func (s *ApplicationSerializationSuite) TestV2ParsingReturnsLatest(c *gc.C) {
 	appLatest.Tools_ = nil
 	appLatest.OperatorStatus_ = nil
 	appLatest.Offers_ = nil
-	appLatest.CharmOrigin_ = nil
+	appLatest.CharmOrigin_ = newCharmOrigin(CharmOriginArgs{
+		Platform: "unknown/ubuntu/20.04",
+	})
 
 	appResult := s.exportImportVersion(c, appV1, 2)
 	appLatest.Series_ = ""
@@ -398,7 +402,9 @@ func (s *ApplicationSerializationSuite) TestV3ParsingReturnsLatest(c *gc.C) {
 	appLatest.DesiredScale_ = 0
 	appLatest.OperatorStatus_ = nil
 	appLatest.Offers_ = nil
-	appLatest.CharmOrigin_ = nil
+	appLatest.CharmOrigin_ = newCharmOrigin(CharmOriginArgs{
+		Platform: "unknown/ubuntu/20.04",
+	})
 
 	appResult := s.exportImportVersion(c, appV2, 3)
 	appLatest.Series_ = ""
@@ -413,7 +419,9 @@ func (s *ApplicationSerializationSuite) TestV5ParsingReturnsLatest(c *gc.C) {
 	// Make an app with fields not in v5 removed.
 	appLatest := appV5
 	appLatest.HasResources_ = false
-	appLatest.CharmOrigin_ = nil
+	appLatest.CharmOrigin_ = newCharmOrigin(CharmOriginArgs{
+		Platform: "unknown/ubuntu/20.04",
+	})
 
 	appResult := s.exportImportVersion(c, appV5, 5)
 	appLatest.Series_ = ""
@@ -427,7 +435,9 @@ func (s *ApplicationSerializationSuite) TestV6ParsingReturnsLatest(c *gc.C) {
 
 	// Make an app with fields not in v6 removed.
 	appLatest := appV6
-	appLatest.CharmOrigin_ = nil
+	appLatest.CharmOrigin_ = newCharmOrigin(CharmOriginArgs{
+		Platform: "unknown/ubuntu/20.04",
+	})
 
 	appResult := s.exportImportVersion(c, appV6, 6)
 	appLatest.Series_ = ""


### PR DESCRIPTION
In the upgrade steps for applications we only upgraded applications from series to platform with version greater then 7 and less then 9. This logic is wrong and need to be all version less then or equal to 9.