### PR TITLE
Add secret revision pending delete attribute

### DIFF
--- a/secrets_test.go
+++ b/secrets_test.go
@@ -68,10 +68,11 @@ func testSecretRevisionsArgs() []SecretRevisionArgs {
 		Content:    map[string]string{"foo": "bar"},
 		Obsolete:   true,
 	}, {
-		Number:   2,
-		Created:  created,
-		Updated:  updated,
-		ValueRef: &valueRef,
+		Number:        2,
+		Created:       created,
+		Updated:       updated,
+		ValueRef:      &valueRef,
+		PendingDelete: true,
 	}}
 }
 
@@ -125,10 +126,12 @@ func (s *SecretsSerializationSuite) TestNewSecret(c *gc.C) {
 	c.Check(secret.Revisions()[0].ExpireTime(), jc.DeepEquals, args.Revisions[0].ExpireTime)
 	c.Check(secret.Revisions()[0].Content(), gc.DeepEquals, map[string]string{"foo": "bar"})
 	c.Check(secret.Revisions()[0].Obsolete(), jc.IsTrue)
+	c.Check(secret.Revisions()[0].PendingDelete(), jc.IsFalse)
 	c.Check(secret.Revisions()[0].ValueRef(), gc.IsNil)
 	c.Check(secret.Revisions()[1].ValueRef().BackendID(), gc.Equals, args.Revisions[1].ValueRef.BackendID)
 	c.Check(secret.Revisions()[1].ValueRef().RevisionID(), gc.Equals, args.Revisions[1].ValueRef.RevisionID)
 	c.Check(secret.Revisions()[1].Obsolete(), jc.IsFalse)
+	c.Check(secret.Revisions()[1].PendingDelete(), jc.IsTrue)
 	c.Check(secret.Revisions()[1].Content(), gc.IsNil)
 	c.Check(secret.ACL()["application-postgresql"].Role(), gc.Equals, "manage")
 	c.Check(secret.ACL()["application-postgresql"].Scope(), gc.Equals, "application-postgresql")


### PR DESCRIPTION
Secret revisions have a pending-delete attribute - add support in the migrate yaml.