### PR TITLE
Add the consume-version field to remote applications

### DIFF
--- a/model.go
+++ b/model.go
@@ -944,7 +944,7 @@ func (m *model) AddRemoteApplication(args RemoteApplicationArgs) RemoteApplicati
 
 func (m *model) setRemoteApplications(appList []*remoteApplication) {
 	m.RemoteApplications_ = remoteApplications{
-		Version:            2,
+		Version:            3,
 		RemoteApplications: appList,
 	}
 }

--- a/model_test.go
+++ b/model_test.go
@@ -828,6 +828,7 @@ func (s *ModelSerializationSuite) TestSerializesRemoteApplications(c *gc.C) {
 		URL:             "other.mysql",
 		SourceModel:     names.NewModelTag("some-model"),
 		IsConsumerProxy: true,
+		ConsumeVersion:  666,
 	})
 	rapp.AddEndpoint(RemoteEndpointArgs{
 		Name:      "db",
@@ -848,7 +849,8 @@ func (s *ModelSerializationSuite) TestSerializesRemoteApplications(c *gc.C) {
 
 	expected := `
 remote-applications:
-- endpoints:
+- consume-version: 666
+  endpoints:
     endpoints:
     - interface: mysql
       name: db
@@ -868,7 +870,7 @@ remote-applications:
       value: running
     version: 2
   url: other.mysql
-version: 2
+version: 3
 `[1:]
 	c.Assert(string(bytes), gc.Equals, expected)
 }

--- a/remoteapplication_test.go
+++ b/remoteapplication_test.go
@@ -54,6 +54,7 @@ func minimalRemoteApplicationMapWithoutStatus() map[interface{}]interface{} {
 		"url":               "http://a.url",
 		"source-model-uuid": "abcd-1234",
 		"is-consumer-proxy": true,
+		"consume-version":   666,
 		"endpoints": map[interface{}]interface{}{
 			"version": 1,
 			"endpoints": []interface{}{map[interface{}]interface{}{
@@ -114,6 +115,7 @@ func minimalRemoteApplicationWithoutStatus() *remoteApplication {
 		URL:             "http://a.url",
 		SourceModel:     names.NewModelTag("abcd-1234"),
 		IsConsumerProxy: true,
+		ConsumeVersion:  666,
 		Bindings:        map[string]string{"lana": "private"},
 	})
 	a.AddEndpoint(RemoteEndpointArgs{
@@ -241,20 +243,31 @@ func (*RemoteApplicationSerializationSuite) TestMinimalMatchesWithoutStatus(c *g
 
 func (s *RemoteApplicationSerializationSuite) TestRoundTripVersion1(c *gc.C) {
 	rIn := minimalRemoteApplication()
+	rIn.ConsumeVersion_ = 0
 	rOut := s.exportImport(c, 1, rIn)
+	rIn.ConsumeVersion_ = 1
 	c.Assert(rOut, jc.DeepEquals, rIn)
 }
 
 func (s *RemoteApplicationSerializationSuite) TestRoundTripVersion2(c *gc.C) {
 	rIn := minimalRemoteApplication()
+	rIn.ConsumeVersion_ = 0
 	rIn.Macaroon_ = "mac"
 	rOut := s.exportImport(c, 2, rIn)
+	rIn.ConsumeVersion_ = 1
+	c.Assert(rOut, jc.DeepEquals, rIn)
+}
+
+func (s *RemoteApplicationSerializationSuite) TestRoundTripVersion3(c *gc.C) {
+	rIn := minimalRemoteApplication()
+	rIn.Macaroon_ = "mac"
+	rOut := s.exportImport(c, 3, rIn)
 	c.Assert(rOut, jc.DeepEquals, rIn)
 }
 
 func (s *RemoteApplicationSerializationSuite) TestRoundTripWithoutStatus(c *gc.C) {
 	rIn := minimalRemoteApplicationWithoutStatus()
-	rOut := s.exportImport(c, 1, rIn)
+	rOut := s.exportImport(c, 3, rIn)
 	c.Assert(rOut, jc.DeepEquals, rIn)
 }
 


### PR DESCRIPTION
The remote application entities were missing the "consume-version" field.
Here we add it, and default to 1 for older exports.