### PR TITLE
Add support for cmr secret artefacts

### DIFF
--- a/remotesecrets.go
+++ b/remotesecrets.go
@@ -1,0 +1,191 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package description
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names/v4"
+	"github.com/juju/schema"
+	"github.com/rs/xid"
+)
+
+// RemoteSecret represents consumer info for a remote secret.
+type RemoteSecret interface {
+	ID() string
+	SourceUUID() string
+	Consumer() (names.Tag, error)
+	Label() string
+	CurrentRevision() int
+	LatestRevision() int
+
+	Validate() error
+}
+
+type remoteSecrets struct {
+	Version        int             `yaml:"version"`
+	RemoteSecrets_ []*remoteSecret `yaml:"remote-secrets"`
+}
+
+type remoteSecret struct {
+	ID_              string `yaml:"id"`
+	SourceUUID_      string `yaml:"source-uuid"`
+	Consumer_        string `yaml:"consumer"`
+	Label_           string `yaml:"label"`
+	CurrentRevision_ int    `yaml:"current-revision"`
+	LatestRevision_  int    `yaml:"latest-revision"`
+}
+
+// RemoteSecretArgs is an argument struct used to create a
+// new internal remote secret type that supports the remote
+// secret interface.
+type RemoteSecretArgs struct {
+	ID              string
+	SourceUUID      string
+	Consumer        names.Tag
+	Label           string
+	CurrentRevision int
+	LatestRevision  int
+}
+
+func newRemoteSecret(args RemoteSecretArgs) *remoteSecret {
+	s := &remoteSecret{
+		ID_:              args.ID,
+		SourceUUID_:      args.SourceUUID,
+		Label_:           args.Label,
+		CurrentRevision_: args.CurrentRevision,
+		LatestRevision_:  args.LatestRevision,
+	}
+	if args.Consumer != nil {
+		s.Consumer_ = args.Consumer.String()
+	}
+	return s
+}
+
+// ID implements RemoteSecret.
+func (i *remoteSecret) ID() string {
+	return i.ID_
+}
+
+// SourceUUID implements RemoteSecret.
+func (i *remoteSecret) SourceUUID() string {
+	return i.SourceUUID_
+}
+
+// Consumer implements RemoteSecret.
+func (i *remoteSecret) Consumer() (names.Tag, error) {
+	if i.Consumer_ == "" {
+		return nil, nil
+	}
+	tag, err := names.ParseTag(i.Consumer_)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return tag, nil
+}
+
+// Label implements RemoteSecret.
+func (i *remoteSecret) Label() string {
+	return i.Label_
+}
+
+// CurrentRevision implements RemoteSecret.
+func (i *remoteSecret) CurrentRevision() int {
+	return i.CurrentRevision_
+}
+
+// LatestRevision implements RemoteSecret.
+func (i *remoteSecret) LatestRevision() int {
+	return i.LatestRevision_
+}
+
+// Validate implements RemoteSecret.
+func (i *remoteSecret) Validate() error {
+	if i.ID_ == "" {
+		return errors.NotValidf("remote secret missing id")
+	}
+	if _, err := xid.FromString(i.ID_); err != nil {
+		return errors.Wrap(err, errors.NotValidf("remote secret ID %q", i.ID_))
+	}
+	if _, err := i.Consumer(); err != nil {
+		return errors.Wrap(err, errors.NotValidf("remote secret %q invalid consumer", i.ID_))
+	}
+	return nil
+}
+
+func importRemoteSecrets(source map[string]interface{}) ([]*remoteSecret, error) {
+	checker := versionedChecker("remote-secrets")
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "remote secret version schema check failed")
+	}
+	valid := coerced.(map[string]interface{})
+
+	version := int(valid["version"].(int64))
+	sourceList := valid["remote-secrets"].([]interface{})
+	return importRemoteSecretList(sourceList, version)
+}
+
+func importRemoteSecretList(sourceList []interface{}, version int) ([]*remoteSecret, error) {
+	getFields, ok := remoteSecretFieldsFuncs[version]
+	if !ok {
+		return nil, errors.NotValidf("version %d", version)
+	}
+
+	result := make([]*remoteSecret, 0, len(sourceList))
+	for i, value := range sourceList {
+		source, ok := value.(map[string]interface{})
+		if !ok {
+			return nil, errors.Errorf("unexpected value for remote secret %d, %T", i, value)
+		}
+		secretConsumer, err := importRemoteSecret(source, version, getFields)
+		if err != nil {
+			return nil, errors.Annotatef(err, "remote secret %d", i)
+		}
+		result = append(result, secretConsumer)
+	}
+	return result, nil
+}
+
+var remoteSecretFieldsFuncs = map[int]fieldsFunc{
+	1: remoteSecretV1Fields,
+}
+
+func remoteSecretV1Fields() (schema.Fields, schema.Defaults) {
+	fields := schema.Fields{
+		"id":               schema.String(),
+		"source-uuid":      schema.String(),
+		"consumer":         schema.String(),
+		"label":            schema.String(),
+		"current-revision": schema.Int(),
+		"latest-revision":  schema.Int(),
+	}
+	// Some values don't have to be there.
+	defaults := schema.Defaults{
+		"label": schema.Omit,
+	}
+	return fields, defaults
+}
+
+func importRemoteSecret(source map[string]interface{}, importVersion int, fieldFunc func() (schema.Fields, schema.Defaults)) (*remoteSecret, error) {
+	fields, defaults := fieldFunc()
+	checker := schema.FieldMap(fields, defaults)
+
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "remote secrets v%d schema check failed", importVersion)
+	}
+	valid := coerced.(map[string]interface{})
+	// From here we know that the map returned from the schema coercion
+	// contains fields of the right type.
+
+	consumer := &remoteSecret{
+		ID_:              valid["id"].(string),
+		SourceUUID_:      valid["source-uuid"].(string),
+		Consumer_:        valid["consumer"].(string),
+		Label_:           valid["label"].(string),
+		CurrentRevision_: int(valid["current-revision"].(int64)),
+		LatestRevision_:  int(valid["latest-revision"].(int64)),
+	}
+	return consumer, nil
+}

--- a/remotesecrets_test.go
+++ b/remotesecrets_test.go
@@ -1,0 +1,103 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package description
+
+import (
+	"github.com/juju/names/v4"
+	jc "github.com/juju/testing/checkers"
+	"github.com/rs/xid"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
+)
+
+type RemoteSecretsSerializationSuite struct {
+	SliceSerializationSuite
+}
+
+var _ = gc.Suite(&RemoteSecretsSerializationSuite{})
+
+func (s *RemoteSecretsSerializationSuite) SetUpTest(c *gc.C) {
+	s.SliceSerializationSuite.SetUpTest(c)
+	s.importName = "remote secret"
+	s.sliceName = "remote-secrets"
+	s.importFunc = func(m map[string]interface{}) (interface{}, error) {
+		return importRemoteSecrets(m)
+	}
+	s.testFields = func(m map[string]interface{}) {
+		m["remote-secrets"] = []interface{}{}
+	}
+}
+
+func testRemoteSecretArgs() RemoteSecretArgs {
+	id := xid.New().String()
+	return RemoteSecretArgs{
+		ID:              id,
+		SourceUUID:      "model-uuid",
+		Consumer:        names.NewApplicationTag("mariadb"),
+		Label:           "secret label",
+		CurrentRevision: 666,
+		LatestRevision:  667,
+	}
+}
+
+func (s *RemoteSecretsSerializationSuite) TestNewRemoteSecret(c *gc.C) {
+	args := testRemoteSecretArgs()
+	remoteSecret := newRemoteSecret(args)
+
+	c.Check(remoteSecret.ID(), gc.Equals, args.ID)
+	c.Check(remoteSecret.SourceUUID(), gc.Equals, "model-uuid")
+	c.Check(remoteSecret.Label(), gc.Equals, "secret label")
+	c.Check(remoteSecret.CurrentRevision(), gc.Equals, 666)
+	c.Check(remoteSecret.LatestRevision(), gc.Equals, 667)
+	consumer, err := remoteSecret.Consumer()
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(consumer, gc.Equals, names.NewApplicationTag("mariadb"))
+}
+
+func (s *RemoteSecretsSerializationSuite) TestRemoteSecretValid(c *gc.C) {
+	args := testRemoteSecretArgs()
+	remoteSecret := newRemoteSecret(args)
+	c.Assert(remoteSecret.Validate(), jc.ErrorIsNil)
+}
+
+func (s *RemoteSecretsSerializationSuite) TestInvalidID(c *gc.C) {
+	v := newRemoteSecret(RemoteSecretArgs{ID: "invalid"})
+	err := v.Validate()
+	c.Assert(err, gc.ErrorMatches, `remote secret ID "invalid" not valid`)
+}
+
+func (s *RemoteSecretsSerializationSuite) TestRemoteSecretMatches(c *gc.C) {
+	args := testRemoteSecretArgs()
+
+	remoteSecret := newRemoteSecret(args)
+	out, err := yaml.Marshal(remoteSecret)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(out), jc.YAMLEquals, remoteSecret)
+}
+
+func (s *RemoteSecretsSerializationSuite) exportImport(c *gc.C, remoteSecret_ *remoteSecret, version int) *remoteSecret {
+	initial := remoteSecrets{
+		Version:        version,
+		RemoteSecrets_: []*remoteSecret{remoteSecret_},
+	}
+
+	bytes, err := yaml.Marshal(initial)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var source map[string]interface{}
+	err = yaml.Unmarshal(bytes, &source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	remoteSecrets, err := importRemoteSecrets(source)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(remoteSecrets, gc.HasLen, 1)
+	return remoteSecrets[0]
+}
+
+func (s *RemoteSecretsSerializationSuite) TestParsingSerializedData(c *gc.C) {
+	args := testRemoteSecretArgs()
+	original := newRemoteSecret(args)
+	remoteSecret := s.exportImport(c, original, 1)
+	c.Assert(remoteSecret, jc.DeepEquals, original)
+}

--- a/secretremoteconsumers.go
+++ b/secretremoteconsumers.go
@@ -1,0 +1,130 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package description
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names/v4"
+	"github.com/juju/schema"
+)
+
+// SecretRemoteConsumer represents consumer info for a secret remote consumer.
+type SecretRemoteConsumer interface {
+	ID() string
+	Consumer() (names.Tag, error)
+	CurrentRevision() int
+	LatestRevision() int
+}
+
+type secretRemoteConsumer struct {
+	ID_              string `yaml:"id"`
+	Consumer_        string `yaml:"consumer"`
+	CurrentRevision_ int    `yaml:"current-revision"`
+
+	// Updated when added to a secret
+	// but not exported.
+	LatestRevision_ int `yaml:"-"`
+}
+
+// SecretRemoteConsumerArgs is an argument struct used to create a
+// new internal remote secret type that supports the secret remote
+// consumer interface.
+type SecretRemoteConsumerArgs struct {
+	ID              string
+	Consumer        names.Tag
+	CurrentRevision int
+}
+
+func newSecretRemoteConsumer(args SecretRemoteConsumerArgs) *secretRemoteConsumer {
+	s := &secretRemoteConsumer{
+		ID_:              args.ID,
+		CurrentRevision_: args.CurrentRevision,
+	}
+	if args.Consumer != nil {
+		s.Consumer_ = args.Consumer.String()
+	}
+	return s
+}
+
+// ID implements SecretRemoteConsumer.
+func (i *secretRemoteConsumer) ID() string {
+	return i.ID_
+}
+
+// Consumer implements SecretRemoteConsumer.
+func (i *secretRemoteConsumer) Consumer() (names.Tag, error) {
+	if i.Consumer_ == "" {
+		return nil, nil
+	}
+	tag, err := names.ParseTag(i.Consumer_)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return tag, nil
+}
+
+// CurrentRevision implements SecretRemoteConsumer.
+func (i *secretRemoteConsumer) CurrentRevision() int {
+	return i.CurrentRevision_
+}
+
+// LatestRevision implements SecretRemoteConsumer.
+func (i *secretRemoteConsumer) LatestRevision() int {
+	return i.LatestRevision_
+}
+
+func importSecretRemoteConsumers(source map[string]interface{}, version int) ([]*secretRemoteConsumer, error) {
+	importFunc, ok := secretRemoteConsumerDeserializationFuncs[version]
+	if !ok {
+		return nil, errors.NotValidf("version %d", version)
+	}
+	sourceList := source["remote-consumers"].([]interface{})
+	return importSecretRemoteConsumersList(sourceList, importFunc)
+}
+
+func importSecretRemoteConsumersList(sourceList []interface{}, importFunc secretRemoteConsumerDeserializationFunc) ([]*secretRemoteConsumer, error) {
+	result := make([]*secretRemoteConsumer, 0, len(sourceList))
+	for i, consumer := range sourceList {
+		source, ok := consumer.(map[interface{}]interface{})
+		if !ok {
+			return nil, errors.Errorf("unexpected value for consumer %d, %T", i, consumer)
+		}
+		consumer, err := importFunc(source)
+		if err != nil {
+			return nil, errors.Annotatef(err, "consumer %v", i)
+		}
+		result = append(result, consumer)
+	}
+	return result, nil
+}
+
+type secretRemoteConsumerDeserializationFunc func(map[interface{}]interface{}) (*secretRemoteConsumer, error)
+
+var secretRemoteConsumerDeserializationFuncs = map[int]secretRemoteConsumerDeserializationFunc{
+	1: importSecretRemoteConsumerV1,
+}
+
+func importSecretRemoteConsumerV1(source map[interface{}]interface{}) (*secretRemoteConsumer, error) {
+	fields := schema.Fields{
+		"id":               schema.String(),
+		"consumer":         schema.String(),
+		"current-revision": schema.Int(),
+	}
+	checker := schema.FieldMap(fields, schema.Defaults{})
+
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "secret remote consumers v1 schema check failed")
+	}
+	valid := coerced.(map[string]interface{})
+	// From here we know that the map returned from the schema coercion
+	// contains fields of the right type.
+
+	consumer := &secretRemoteConsumer{
+		ID_:              valid["id"].(string),
+		Consumer_:        valid["consumer"].(string),
+		CurrentRevision_: int(valid["current-revision"].(int64)),
+	}
+	return consumer, nil
+}


### PR DESCRIPTION
For cross model secrets, we have 2 additional types of data to include in the model:
- remote consumer info (for local secrets) in the offering model
- consumer info for remote (offered) secrets in the consumer model

This PR adds both of the above. Consumer info for remote secrets is stored in a separate yaml collection. For remote consumers, these are added to the offer secrets next to the local consumers.
