### PR TITLE
[JUJU-3330] Add user removed log entries to user v2

### DIFF
--- a/user_test.go
+++ b/user_test.go
@@ -88,3 +88,71 @@ func (*UserSerializationSuite) TestParsingSerializedData(c *gc.C) {
 
 	c.Assert(users, jc.DeepEquals, initial.Users_)
 }
+
+func (*UserSerializationSuite) TestParsingLogEntries(c *gc.C) {
+	lastConn := time.Date(2016, 1, 15, 12, 0, 0, 0, time.UTC)
+	removalLog := []userRemovedLogEntry{
+		{
+			RemovedBy_:   "jimmy",
+			DateCreated_: time.Date(2015, 11, 9, 12, 34, 56, 0, time.UTC),
+			DateRemoved_: time.Date(2015, 12, 9, 12, 34, 56, 0, time.UTC),
+		},
+	}
+	removalLogMultiEntry := []userRemovedLogEntry{
+		{
+			RemovedBy_:   "admin",
+			DateCreated_: time.Date(2015, 11, 9, 12, 34, 56, 0, time.UTC),
+			DateRemoved_: time.Date(2015, 12, 9, 12, 34, 56, 0, time.UTC),
+		},
+		{
+			RemovedBy_:   "admin2",
+			DateCreated_: time.Date(2017, 11, 9, 12, 34, 56, 0, time.UTC),
+			DateRemoved_: time.Date(2017, 12, 9, 12, 34, 56, 0, time.UTC),
+		},
+	}
+
+	initial := users{
+		Version: 2,
+		Users_: []*user{
+			{
+				Name_:           "admin",
+				CreatedBy_:      "admin",
+				DateCreated_:    time.Date(2015, 10, 9, 12, 34, 56, 0, time.UTC),
+				LastConnection_: &lastConn,
+				RemovalLog_:     removalLog,
+			},
+			{
+				Name_:           "user2",
+				CreatedBy_:      "admin",
+				DateCreated_:    time.Date(2015, 10, 9, 12, 34, 56, 0, time.UTC),
+				LastConnection_: &lastConn,
+				Access_:         "read",
+			},
+			{
+				Name_:           "user3",
+				CreatedBy_:      "admin",
+				DateCreated_:    time.Date(2015, 10, 9, 12, 34, 56, 0, time.UTC),
+				LastConnection_: &lastConn,
+				RemovalLog_:     removalLogMultiEntry,
+			},
+		},
+	}
+
+	bytes, err := yaml.Marshal(initial)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Logf("%s", bytes)
+
+	var source map[string]interface{}
+	err = yaml.Unmarshal(bytes, &source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	users, err := importUsers(source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(users, jc.DeepEquals, initial.Users_)
+	c.Assert(users[0].RemovalLog_, jc.DeepEquals, removalLog)
+	c.Assert(len(users[1].RemovalLog_), gc.Equals, 0)
+	c.Assert(len(users[2].RemovalLog_), gc.Equals, 2)
+	c.Assert(users[2].RemovalLog_, jc.DeepEquals, removalLogMultiEntry)
+}


### PR DESCRIPTION
After the addition of the removal log [here](https://github.com/juju/juju/pull/15266), we have to update the description package so we can migrate between versions. This PR basically adds the array of user removed entries to the version2 of `user` values.

I assume this change will have to be ported to v4 too.