### PR TITLE
Application lease

### DIFF
--- a/lease.go
+++ b/lease.go
@@ -1,0 +1,136 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package description
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/schema"
+)
+
+// Lease represents a Lease for a given application. This doesn't include the
+// singular controller lease.
+type Lease interface {
+	Name() string
+	Holder() string
+	Start() time.Time
+	Expiry() time.Time
+	Pinned() bool
+}
+
+var _ Lease = (*lease)(nil)
+
+type lease struct {
+	Version_ int       `yaml:"version"`
+	Name_    string    `yaml:"name"`
+	Holder_  string    `yaml:"holder"`
+	Start_   time.Time `yaml:"start"`
+	Expiry_  time.Time `yaml:"expiry"`
+	Pinned_  bool      `yaml:"pinned"`
+}
+
+// LeaseArgs is an argument struct used to add a lease to the model.
+type LeaseArgs struct {
+	Name   string
+	Holder string
+	Start  time.Time
+	Expiry time.Time
+	Pinned bool
+}
+
+func newLease(args *LeaseArgs) *lease {
+	if args == nil {
+		return nil
+	}
+
+	return &lease{
+		Version_: 1,
+		Name_:    args.Name,
+		Holder_:  args.Holder,
+		Start_:   args.Start,
+		Expiry_:  args.Expiry,
+		Pinned_:  args.Pinned,
+	}
+}
+
+// Name implements Lease.
+func (l *lease) Name() string {
+	return l.Name_
+}
+
+// Holder implements Lease.
+func (l *lease) Holder() string {
+	return l.Holder_
+}
+
+// Start implements Lease.
+func (l *lease) Start() time.Time {
+	return l.Start_
+}
+
+// Expiry implements Lease.
+func (l *lease) Expiry() time.Time {
+	return l.Expiry_
+}
+
+// Pinned implements Lease.
+func (l *lease) Pinned() bool {
+	return l.Pinned_
+}
+
+func importLease(source map[string]any) (*lease, error) {
+	version, err := getVersion(source)
+	if err != nil {
+		return nil, errors.Annotate(err, "lease version schema check failed")
+	}
+	importFunc, ok := leaseDeserializationFuncs[version]
+	if !ok {
+		return nil, errors.NotValidf("version %d", version)
+	}
+	return importFunc(source)
+}
+
+type leaseDeserializationFunc func(map[string]any) (*lease, error)
+
+var leaseDeserializationFuncs = map[int]leaseDeserializationFunc{
+	1: importLeaseV1,
+}
+
+func importLeaseV1(source map[string]any) (*lease, error) {
+	fields, defaults := leaseV1Schema()
+	checker := schema.FieldMap(fields, defaults)
+
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "lease v1 schema check failed")
+	}
+
+	return leaseV1(coerced.(map[string]any)), nil
+}
+
+func leaseV1Schema() (schema.Fields, schema.Defaults) {
+	fields := schema.Fields{
+		"name":   schema.String(),
+		"holder": schema.String(),
+		"start":  schema.Time(),
+		"expiry": schema.Time(),
+		"pinned": schema.Bool(),
+	}
+	defaults := schema.Defaults{
+		"pinned": false,
+	}
+	return fields, defaults
+}
+
+func leaseV1(valid map[string]any) *lease {
+	return &lease{
+		Version_: 1,
+		Name_:    valid["name"].(string),
+		Holder_:  valid["holder"].(string),
+		Start_:   valid["start"].(time.Time).UTC(),
+		Expiry_:  valid["expiry"].(time.Time).UTC(),
+		Pinned_:  valid["pinned"].(bool),
+	}
+}

--- a/lease_test.go
+++ b/lease_test.go
@@ -1,0 +1,129 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package description
+
+import (
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
+)
+
+type LeaseSerializationSuite struct {
+	SerializationSuite
+}
+
+var _ = gc.Suite(&LeaseSerializationSuite{})
+
+func (s *LeaseSerializationSuite) SetUpTest(c *gc.C) {
+	s.importName = "lease"
+	s.importFunc = func(m map[string]any) (any, error) {
+		return importLease(m)
+	}
+}
+
+func (s *LeaseSerializationSuite) TestNewLease(c *gc.C) {
+	now := time.Now().UTC().Round(time.Second)
+	args := LeaseArgs{
+		Name:   "name",
+		Holder: "holder",
+		Start:  now,
+		Expiry: now.Add(10 * time.Minute),
+		Pinned: true,
+	}
+	instance := newLease(&args)
+	c.Assert(instance.Name(), gc.Equals, "name")
+	c.Assert(instance.Holder(), gc.Equals, "holder")
+	c.Assert(instance.Start(), gc.DeepEquals, now)
+	c.Assert(instance.Expiry(), gc.DeepEquals, now.Add(10*time.Minute))
+	c.Assert(instance.Pinned(), jc.IsTrue)
+}
+
+func minimalLeaseMap(now time.Time) map[any]any {
+	return map[any]any{
+		"version": 1,
+		"name":    "name",
+		"holder":  "holder",
+		"start":   now.Format(time.RFC3339Nano),
+		"expiry":  now.Add(10 * time.Minute).Format(time.RFC3339Nano),
+		"pinned":  true,
+	}
+}
+
+func minimalLeaseArgs(now time.Time) *LeaseArgs {
+	return &LeaseArgs{
+		Name:   "name",
+		Holder: "holder",
+		Start:  now,
+		Expiry: now.Add(10 * time.Minute),
+		Pinned: true,
+	}
+}
+
+func minimalLease(now time.Time) *lease {
+	return newLease(minimalLeaseArgs(now))
+}
+
+func maximalLeaseMap(now time.Time) map[any]any {
+	return map[any]any{
+		"version": 1,
+		"name":    "name",
+		"holder":  "holder",
+		"start":   now.Format(time.RFC3339Nano),
+		"expiry":  now.Add(10 * time.Minute).Format(time.RFC3339Nano),
+		"pinned":  true,
+	}
+}
+
+func maximalLeaseArgs(now time.Time) *LeaseArgs {
+	return &LeaseArgs{
+		Name:   "name",
+		Holder: "holder",
+		Start:  now,
+		Expiry: now.Add(10 * time.Minute),
+		Pinned: true,
+	}
+}
+
+func maximalLease(now time.Time) *lease {
+	return newLease(maximalLeaseArgs(now))
+}
+
+func (s *LeaseSerializationSuite) TestMinimalMatches(c *gc.C) {
+	now := time.Now().UTC().Round(time.Second)
+	bytes, err := yaml.Marshal(minimalLease(now))
+	c.Assert(err, jc.ErrorIsNil)
+
+	var source map[any]any
+	err = yaml.Unmarshal(bytes, &source)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(source, jc.DeepEquals, minimalLeaseMap(now))
+}
+
+func (s *LeaseSerializationSuite) TestMaximalMatches(c *gc.C) {
+	now := time.Now().UTC().Round(time.Second)
+	bytes, err := yaml.Marshal(maximalLease(now))
+	c.Assert(err, jc.ErrorIsNil)
+
+	var source map[any]any
+	err = yaml.Unmarshal(bytes, &source)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(source, jc.DeepEquals, maximalLeaseMap(now))
+}
+
+func (s *LeaseSerializationSuite) TestParsingSerializedData(c *gc.C) {
+	now := time.Now().UTC().Round(time.Second)
+	initial := maximalLease(now)
+	bytes, err := yaml.Marshal(initial)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var source map[string]any
+	err = yaml.Unmarshal(bytes, &source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	instance, err := importLease(source)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(instance, jc.DeepEquals, initial)
+}

--- a/model.go
+++ b/model.go
@@ -458,7 +458,7 @@ func (m *model) AddApplication(args ApplicationArgs) Application {
 
 func (m *model) setApplications(applicationList []*application) {
 	m.Applications_ = applications{
-		Version:       11,
+		Version:       12,
 		Applications_: applicationList,
 	}
 }

--- a/provisioningstate_test.go
+++ b/provisioningstate_test.go
@@ -103,17 +103,3 @@ func (s *ProvisioningStateSerializationSuite) TestParsingSerializedData(c *gc.C)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(instance, jc.DeepEquals, initial)
 }
-
-func (s *ProvisioningStateSerializationSuite) exportImportVersion(c *gc.C, origin_ *provisioningState, version int) *provisioningState {
-	origin_.Version_ = version
-	bytes, err := yaml.Marshal(origin_)
-	c.Assert(err, jc.ErrorIsNil)
-
-	var source map[string]interface{}
-	err = yaml.Unmarshal(bytes, &source)
-	c.Assert(err, jc.ErrorIsNil)
-
-	origin, err := importProvisioningState(source)
-	c.Assert(err, jc.ErrorIsNil)
-	return origin
-}


### PR DESCRIPTION
Add leases to applications so we can migrate the lease. This will keep leases the same on applications when we perform model migrations. This should elevate the need to claim a leader when performing the application migration for a model and addition will prevent needless churn of the leaders when migrating.

This bumps the application to v12. This does mean that we have to be careful in relation to 3.x releases as the intended target for this is the 4.x release of juju.