### PR TITLE
Add missing serial id attribute to block devices

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -318,7 +318,7 @@ func (m *machine) AddBlockDevice(args BlockDeviceArgs) BlockDevice {
 
 func (m *machine) setBlockDevices(devices []*blockdevice) {
 	m.BlockDevices_ = blockdevices{
-		Version:       1,
+		Version:       2,
 		BlockDevices_: devices,
 	}
 }

--- a/model.go
+++ b/model.go
@@ -4,6 +4,7 @@
 package description
 
 import (
+	"fmt"
 	"net"
 	"sort"
 	"strings"
@@ -136,6 +137,8 @@ type Model interface {
 	MeterStatus() MeterStatus
 
 	PasswordHash() string
+
+	AddBlockDevice(string, BlockDeviceArgs) error
 }
 
 // ModelArgs represent the bare minimum information that is needed
@@ -429,6 +432,18 @@ func (m *model) setMachines(machineList []*machine) {
 		Version:   3,
 		Machines_: machineList,
 	}
+}
+
+// AddBlockDevice adds a block device for the specified machine.
+func (m *model) AddBlockDevice(machineId string, bdArgs BlockDeviceArgs) error {
+	for i := range m.Machines_.Machines_ {
+		if m.Machines_.Machines_[i].Id_ != machineId {
+			continue
+		}
+		m.Machines_.Machines_[i].AddBlockDevice(bdArgs)
+		return nil
+	}
+	return fmt.Errorf("machine %q %w", machineId, errors.NotFound)
 }
 
 // Applications implements Model.


### PR DESCRIPTION
Twp changes to block device handling:
- add missing serial id attribute to block devices
- add new model method to add a block device to a specified machine

The block device entity has missing a serial id attribute which was added to juju and not updated here.

With the move of juju to dqlite, exporting a model will result in all block devices being loaded separately to machines. So we need a new helper method on model to allow block devices to be added for a specific machine id, rather than being part of the machine entity itself.