### PR TITLE
Allow the cloud service provider id to be empty when importing

### DIFF
--- a/cloudservice.go
+++ b/cloudservice.go
@@ -102,9 +102,10 @@ func importCloudServiceV1(source map[string]interface{}) (*cloudService, error) 
 	}
 	valid := coerced.(map[string]interface{})
 
+	providerId, _ := valid["provider-id"].(string)
 	cloudService := &cloudService{
 		Version:     1,
-		ProviderId_: valid["provider-id"].(string),
+		ProviderId_: providerId,
 	}
 	if addresses, ok := valid["addresses"]; ok {
 		serviceAddresses, err := importAddresses(addresses.([]interface{}))

--- a/cloudservice_test.go
+++ b/cloudservice_test.go
@@ -64,3 +64,19 @@ func (s *CloudServiceSerializationSuite) TestParsingSerializedData(c *gc.C) {
 
 	c.Assert(imported, jc.DeepEquals, initial)
 }
+
+func (s *CloudServiceSerializationSuite) TestParsingMinimalSerializedData(c *gc.C) {
+	initial := newCloudService(&CloudServiceArgs{})
+
+	bytes, err := yaml.Marshal(initial)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var source map[string]interface{}
+	err = yaml.Unmarshal(bytes, &source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	imported, err := importCloudService(source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(imported, jc.DeepEquals, initial)
+}


### PR DESCRIPTION
We've seen a case where the cloud service provider id arrives as empty, and import panics. The import code uses Omit as the default value anyway, so this fixes how empty provider ids are handled.