### PR TITLE
Cater for omitted fields in secrets import

### DIFF
--- a/secretremoteconsumers.go
+++ b/secretremoteconsumers.go
@@ -79,7 +79,10 @@ func importSecretRemoteConsumers(source map[string]interface{}, version int) ([]
 	if !ok {
 		return nil, errors.NotValidf("version %d", version)
 	}
-	sourceList := source["remote-consumers"].([]interface{})
+	sourceList, ok := source["remote-consumers"].([]interface{})
+	if !ok {
+		return nil, nil
+	}
 	return importSecretRemoteConsumersList(sourceList, importFunc)
 }
 


### PR DESCRIPTION
Secrets has fields like "auto-prune", "rotate-policy" which can be empty but which would then cause the import to panic. 
Imports from 3.1 (which didn't have auto-prune) to 3.4 would fail.

This PR adds checks for these fields to avoid the panic, and also defensively does the same for some other similar fields in the attribute map. This will fix the missing "auto-prune" issue and avoid accidental breakage in the future. Even though the checks for the coercion to []interface{} are strictly not needed, being explicit helps readability.
