### PR TITLE
chore: bump main version to v8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROJECT := github.com/juju/description/v6
+PROJECT := github.com/juju/description/v8
 
 .PHONY: check-licence check-go check
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/juju/description/v6
+module github.com/juju/description/v8
 
 go 1.21
 

--- a/package_test.go
+++ b/package_test.go
@@ -25,7 +25,7 @@ var _ = gc.Suite(&ImportTest{})
 
 func (*ImportTest) TestImports(c *gc.C) {
 	imps, err := jtesting.FindImports(
-		"github.com/juju/description/v6",
+		"github.com/juju/description/v8",
 		"github.com/juju/juju/")
 	c.Assert(err, jc.ErrorIsNil)
 	// This package brings in nothing else from juju/juju


### PR DESCRIPTION
The v8 is a placeholder for the main branch. If we ever need to use v8 for a 3.6 or 3.7 release, then we can just bump this to v9. We should never release this branch to main, until it's being released.