### PR TITLE
chore: bump v7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROJECT := github.com/juju/description/v5
+PROJECT := github.com/juju/description/v7
 
 .PHONY: check-licence check-go check
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/juju/description/v5
+module github.com/juju/description/v7
 
 go 1.21
 

--- a/package_test.go
+++ b/package_test.go
@@ -25,7 +25,7 @@ var _ = gc.Suite(&ImportTest{})
 
 func (*ImportTest) TestImports(c *gc.C) {
 	imps, err := jtesting.FindImports(
-		"github.com/juju/description/v5",
+		"github.com/juju/description/v7",
 		"github.com/juju/juju/")
 	c.Assert(err, jc.ErrorIsNil)
 	// This package brings in nothing else from juju/juju


### PR DESCRIPTION
This bumps the branch to v7. This leapfrogs over v6, but has all the same features as v5, with the additional metadata and manifest for application charms.