### PR TITLE
feat: expose application getter/setters

### DIFF
--- a/application.go
+++ b/application.go
@@ -67,6 +67,12 @@ type Application interface {
 	CharmManifest() CharmManifest
 	SetCharmManifest(CharmManifestArgs)
 
+	CharmActions() CharmActions
+	SetCharmActions(CharmActionsArgs)
+
+	CharmConfigs() CharmConfigs
+	SetCharmConfigs(CharmConfigsArgs)
+
 	Tools() AgentTools
 	SetTools(AgentToolsArgs)
 


### PR DESCRIPTION
It's handy to expose the application getters and setters. That way we can work with the interface.