### PR TITLE
feat: expose lxd profile on charm metadata

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -260,6 +260,7 @@ type CharmMetadata interface {
 	Resources() map[string]CharmMetadataResource
 	Terms() []string
 	Containers() map[string]CharmMetadataContainer
+	LXDProfile() string
 }
 
 // CharmMetadataRelation represents a relation in the metadata of a charm.


### PR DESCRIPTION
The expose LXD profile on the charm metadata inferface. Doing this, allows us to expose the LXD profile for importing the charm.

The charm metadata type already exposed the LXDProfile method, it was an oversight to not add it to the interface.