### PR TITLE
feat: authorized keys onto model description

### DIFF
--- a/authorizedkeys.go
+++ b/authorizedkeys.go
@@ -1,0 +1,134 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package description
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/schema"
+)
+
+// authorizedKeys is the internal package representation of the authorized key
+// that are on a model.
+type authorizedKeys struct {
+	Version int `yaml:"version"`
+
+	// UserAuthorizedKeys is a list of users and their authorized keys for a
+	// model.
+	UserAuthorizedKeys_ []*userAuthorizedKeys `yaml:"users-authorized-keys"`
+}
+
+// userAuthorizedKeys represents the authorized keys that a user has on a model.
+type userAuthorizedKeys struct {
+	Username_       string   `yaml:"user-name"`
+	AuthorizedKeys_ []string `yaml:"authorized-keys"`
+}
+
+// UserAuthorizedKeysArgs is the arguments struct used for adding new authorized
+// keys to the model.
+type UserAuthorizedKeysArgs struct {
+	// Username is the username of the user on the model that owns the
+	// authorized keys.
+	Username string
+
+	// AuthorizedKeys is the set of authorized keys for the user on the model.
+	AuthorizedKeys []string
+}
+
+// userAuthorizedKeysDeserializationFunc describes a type of function that is
+// capable of deserializing raw users-authorized-keys attributes in
+// [authorizedKeys]
+type userAuthorizedKeysDeserializationFunc func(map[string]any) (*userAuthorizedKeys, error)
+
+// userAuthorizedKeysDeserializationFuncs provides a mapping of [authorizedKeys]
+// versions to the respective deserialization functions.
+var userAuthorizedKeysDeserializationFuncs = map[int]userAuthorizedKeysDeserializationFunc{
+	1: importAuthorizedKeysV1,
+}
+
+// newUserAuthorizedKeys creates a new [userAuthorizedKeys] from the supplied
+// arguments.
+func newUserAuthorizedKeys(args UserAuthorizedKeysArgs) *userAuthorizedKeys {
+	return &userAuthorizedKeys{
+		Username_:       args.Username,
+		AuthorizedKeys_: args.AuthorizedKeys,
+	}
+}
+
+// Username returns the username the owns the authorized keys in this struct.
+// Implements [UserAuthorizedKeys] interface.
+func (i *userAuthorizedKeys) Username() string {
+	return i.Username_
+}
+
+// AuthorizedKeys returns the authorized keys for this user. Implements
+// [UserAuthorizedKeys] interface.
+func (i *userAuthorizedKeys) AuthorizedKeys() []string {
+	return i.AuthorizedKeys_
+}
+
+// importAuthorizedKeys provides the deserialization method for importing a
+// model's authorized keys. It will handle version changes of this type.
+func importAuthorizedKeys(source map[string]any) ([]*userAuthorizedKeys, error) {
+	checker := versionedChecker("users-authorized-keys")
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "users-authorized-keys version schema check failed")
+	}
+	valid := coerced.(map[string]interface{})
+
+	version := int(valid["version"].(int64))
+	importFunc, ok := userAuthorizedKeysDeserializationFuncs[version]
+	if !ok {
+		return nil, errors.NotValidf("version %d", version)
+	}
+	sourceList := valid["users-authorized-keys"].([]interface{})
+	return importUserAuthorizedKeysList(sourceList, importFunc)
+}
+
+// importUserAuthorizedKeysList provides a deserialization method for handling
+// the list of user authorized keys for a model.
+func importUserAuthorizedKeysList(
+	sourceList []any,
+	importFunc userAuthorizedKeysDeserializationFunc,
+) ([]*userAuthorizedKeys, error) {
+	result := make([]*userAuthorizedKeys, 0, len(sourceList))
+	for i, value := range sourceList {
+		source, ok := value.(map[string]any)
+		if !ok {
+			return nil, errors.Errorf("unexpected value for users-authorized-keys %d, %T", i, value)
+		}
+		userAuthorizedKeys, err := importFunc(source)
+		if err != nil {
+			return nil, errors.Annotatef(err, "user-authorized-keys %d", i)
+		}
+		result = append(result, userAuthorizedKeys)
+	}
+	return result, nil
+}
+
+// importAuthorizedKeysV1 implements a [userAuthorizedKeysDeserializationFunc]
+// for deserializing version 1 user authorized keys.
+func importAuthorizedKeysV1(source map[string]any) (*userAuthorizedKeys, error) {
+	fields := schema.Fields{
+		"user-name":       schema.String(),
+		"authorized-keys": schema.List(schema.String()),
+	}
+	defaults := schema.Defaults{}
+	checker := schema.FieldMap(fields, defaults)
+
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "userAuthorizedKeys v1 schema check failed")
+	}
+	valid := coerced.(map[string]interface{})
+	keysInterface := valid["authorized-keys"].([]interface{})
+	keys := make([]string, len(keysInterface))
+	for i, d := range keysInterface {
+		keys[i] = d.(string)
+	}
+	return &userAuthorizedKeys{
+		Username_:       valid["user-name"].(string),
+		AuthorizedKeys_: keys,
+	}, nil
+}

--- a/authorizedkeys_test.go
+++ b/authorizedkeys_test.go
@@ -1,0 +1,108 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package description
+
+import (
+	"slices"
+	"strings"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
+)
+
+type AuthorizedKeysSerializationSuite struct {
+	SliceSerializationSuite
+}
+
+var _ = gc.Suite(&AuthorizedKeysSerializationSuite{})
+
+func (s *AuthorizedKeysSerializationSuite) SetUpTest(c *gc.C) {
+	s.SliceSerializationSuite.SetUpTest(c)
+	s.importName = "users-authorized-keys"
+	s.sliceName = "users-authorized-keys"
+	s.importFunc = func(m map[string]any) (any, error) {
+		return importAuthorizedKeys(m)
+	}
+	s.testFields = func(m map[string]any) {
+		m["users-authorized-keys"] = []any{}
+	}
+}
+
+// TestNewUserAuthorizedKeys is testing that given a set of arguments we get
+// back a [userAuthorizedKeys] struct that contains the information passed in
+// via args.
+func (s *AuthorizedKeysSerializationSuite) TestNewUserAuthorizedKeys(c *gc.C) {
+	args := UserAuthorizedKeysArgs{
+		Username: "tlm",
+		AuthorizedKeys: []string{
+			"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII4GpCvqUUYUJlx6d1kpUO9k/t4VhSYsf0yE0/QTqDzC existing1",
+			"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJQJ9wv0uC3yytXM3d2sJJWvZLuISKo7ZHwafHVviwVe existing2",
+		},
+	}
+
+	uak := newUserAuthorizedKeys(args)
+	c.Check(uak.Username(), gc.Equals, "tlm")
+	c.Check(uak.AuthorizedKeys(), jc.DeepEquals, []string{
+		"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII4GpCvqUUYUJlx6d1kpUO9k/t4VhSYsf0yE0/QTqDzC existing1",
+		"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJQJ9wv0uC3yytXM3d2sJJWvZLuISKo7ZHwafHVviwVe existing2",
+	})
+}
+
+// TestParsingSerializedData is asserting that we can marshal and unmarshal user
+// authorized keys to from the go types to yaml and get back the data we expect.
+// We give a two user example below to demonstrate a more complex scenario.
+func (s *AuthorizedKeysSerializationSuite) TestParsingSerializedData(c *gc.C) {
+	initial := authorizedKeys{
+		Version: 1,
+		UserAuthorizedKeys_: []*userAuthorizedKeys{
+			newUserAuthorizedKeys(UserAuthorizedKeysArgs{
+				Username: "tlm",
+				AuthorizedKeys: []string{
+					"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII4GpCvqUUYUJlx6d1kpUO9k/t4VhSYsf0yE0/QTqDzC existing1",
+					"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJQJ9wv0uC3yytXM3d2sJJWvZLuISKo7ZHwafHVviwVe existing2",
+				},
+			}),
+			newUserAuthorizedKeys(UserAuthorizedKeysArgs{
+				Username: "wallyworld",
+				AuthorizedKeys: []string{
+					"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII4GpCvqUUYUJlx6d1kpUO9k/t4VhSYsf0yE0/QTqDzC existing1",
+					"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJQJ9wv0uC3yytXM3d2sJJWvZLuISKo7ZHwafHVviwVe existing2",
+				},
+			}),
+		},
+	}
+
+	bytes, err := yaml.Marshal(initial)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var source map[string]any
+	err = yaml.Unmarshal(bytes, &source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	usersAuthorizedKeys, err := importAuthorizedKeys(source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	slices.SortFunc(usersAuthorizedKeys, func(a, b *userAuthorizedKeys) int {
+		return strings.Compare(a.Username(), b.Username())
+	})
+
+	c.Check(usersAuthorizedKeys, jc.DeepEquals, []*userAuthorizedKeys{
+		newUserAuthorizedKeys(UserAuthorizedKeysArgs{
+			Username: "tlm",
+			AuthorizedKeys: []string{
+				"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII4GpCvqUUYUJlx6d1kpUO9k/t4VhSYsf0yE0/QTqDzC existing1",
+				"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJQJ9wv0uC3yytXM3d2sJJWvZLuISKo7ZHwafHVviwVe existing2",
+			},
+		}),
+		newUserAuthorizedKeys(UserAuthorizedKeysArgs{
+			Username: "wallyworld",
+			AuthorizedKeys: []string{
+				"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII4GpCvqUUYUJlx6d1kpUO9k/t4VhSYsf0yE0/QTqDzC existing1",
+				"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJQJ9wv0uC3yytXM3d2sJJWvZLuISKo7ZHwafHVviwVe existing2",
+			},
+		}),
+	},
+	)
+}

--- a/interfaces.go
+++ b/interfaces.go
@@ -61,6 +61,18 @@ type IPAddress interface {
 	IsSecondary() bool
 }
 
+// UserAuthorizedKeys represents the authorized keys that are in a model for a
+// given user.
+type UserAuthorizedKeys interface {
+	// Username returns the username of the model user for which the authorized
+	// keys belong to.
+	Username() string
+
+	// AuthorizedKeys returns the set of authorized keys allowed on the model
+	// for the user.
+	AuthorizedKeys() []string
+}
+
 // SSHHostKey represents an ssh host key.
 type SSHHostKey interface {
 	MachineID() string

--- a/model_test.go
+++ b/model_test.go
@@ -1167,7 +1167,7 @@ func (s *ModelSerializationSuite) TestSerializesToLatestVersion(c *gc.C) {
 	c.Assert(ok, jc.IsTrue)
 	version, ok := versionValue.(int)
 	c.Assert(ok, jc.IsTrue)
-	c.Assert(version, gc.Equals, 11)
+	c.Assert(version, gc.Equals, 12)
 }
 
 func (s *ModelSerializationSuite) TestVersion1Works(c *gc.C) {


### PR DESCRIPTION
In juju 4.0 authorized keys are coming off of model config and becoming a first class attribute on the model. This now allows for the description package to transport this data over the wire.

Run unit tests to confirm coverage.

JUJU-6280