### PR TITLE
feat: allow setting blocks

### DIFF
--- a/model.go
+++ b/model.go
@@ -53,6 +53,7 @@ type Model interface {
 	// Blocks returns a map of block type to the message associated with that
 	// block.
 	Blocks() map[string]string
+	SetBlocks(map[string]string)
 
 	Users() []User
 	AddUser(UserArgs)
@@ -390,6 +391,11 @@ func (m *model) EnvironVersion() int {
 // Blocks implements Model.
 func (m *model) Blocks() map[string]string {
 	return m.Blocks_
+}
+
+// SetBlocks implements Model.
+func (m *model) SetBlocks(blocks map[string]string) {
+	m.Blocks_ = blocks
 }
 
 // ByName is a sorting implementation over the UserTag lexicographically, which

--- a/model_test.go
+++ b/model_test.go
@@ -157,6 +157,35 @@ func (s *ModelSerializationSuite) TestVersions(c *gc.C) {
 	c.Assert(initial.ExternalControllers_.Version, gc.Equals, len(externalControllerDeserializationFuncs))
 }
 
+func (s *ModelSerializationSuite) TestSetBlocks(c *gc.C) {
+	args := ModelArgs{
+		Type:  IAAS,
+		Owner: names.NewUserTag("magic"),
+		Config: map[string]interface{}{
+			"name": "awesome",
+			"uuid": "some-uuid",
+		},
+		LatestToolsVersion: version.MustParse("2.0.1"),
+		EnvironVersion:     123,
+		Blocks: map[string]string{
+			"all-changes": "locked down",
+		},
+		Cloud:       "vapour",
+		CloudRegion: "east-west",
+	}
+	initial := NewModel(args).(*model)
+
+	initial.SetBlocks(map[string]string{
+		"all-changes": "unlocked",
+		"some-other":  "value",
+	})
+
+	c.Assert(initial.Blocks(), jc.DeepEquals, map[string]string{
+		"all-changes": "unlocked",
+		"some-other":  "value",
+	})
+}
+
 func (s *ModelSerializationSuite) TestParsingYAML(c *gc.C) {
 	s.testParsingYAMLWithMachine(c, func(initial Model) {
 		addMinimalMachine(initial, "0")


### PR DESCRIPTION
When creating a model using the description package, we have to set the blocks when creating it. This isn't useful in the new model instead we need a method.

This exposes the setting of the blocks from the block commands migration export code.