### PR TITLE
fix(instancedata): remove validation checks for instance data

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -386,12 +386,6 @@ func (m *machine) Validate() error {
 	if m.Tools_ == nil {
 		return errors.NotValidf("machine %q missing tools", m.Id_)
 	}
-	if m.Instance_ == nil {
-		return errors.NotValidf("machine %q missing instance", m.Id_)
-	}
-	if err := m.Instance_.Validate(); err != nil {
-		return errors.Annotatef(err, "machine %q instance", m.Id_)
-	}
 	for _, container := range m.Containers_ {
 		if err := container.Validate(); err != nil {
 			return errors.Trace(err)

--- a/machine_test.go
+++ b/machine_test.go
@@ -199,25 +199,6 @@ func (s *MachineSerializationSuite) TestValidateMissingTools(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, `machine "42" missing tools not valid`)
 }
 
-func (s *MachineSerializationSuite) TestValidateMissingInstance(c *gc.C) {
-	m := newMachine(s.machineArgs("42"))
-	m.SetStatus(minimalStatusArgs())
-	m.SetTools(minimalAgentToolsArgs())
-	err := m.Validate()
-	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `machine "42" missing instance not valid`)
-}
-
-func (s *MachineSerializationSuite) TestValidateChecksInstance(c *gc.C) {
-	m := newMachine(s.machineArgs("42"))
-	m.SetStatus(minimalStatusArgs())
-	m.SetTools(minimalAgentToolsArgs())
-	m.SetInstance(minimalCloudInstanceArgs())
-	err := m.Validate()
-	c.Check(err, jc.Satisfies, errors.IsNotValid)
-	c.Check(err, gc.ErrorMatches, `machine "42" instance: instance "instance id" missing status not valid`)
-}
-
 func (s *MachineSerializationSuite) TestNewMachineWithSupportedContainers(c *gc.C) {
 	supported := []string{"lxd", "kvm"}
 	args := s.machineArgs("id")


### PR DESCRIPTION
Migration is currently failing on the PR https://github.com/juju/juju/pull/18214 because the validation (that runs *after* we fill the model on the legacy state but *before* we fill it with the new domain migrations) returns an error when trying to migrate a machine that's not provisioned.

While this check is indeed OK, the fact that we are performing it in a serialization library is a bad idea. Business logic should only live in juju, not here.

This patch removes the instance Validation() from machine Validation().