### PR TITLE
feat: add CIDR support to Address structure

### DIFF
--- a/address_test.go
+++ b/address_test.go
@@ -119,3 +119,27 @@ func (*AddressSerializationSuite) TestParsingSerializedDataV2(c *gc.C) {
 
 	c.Assert(addresss, jc.DeepEquals, initial)
 }
+
+func (*AddressSerializationSuite) TestParsingSerializedDataV3(c *gc.C) {
+	initial := &address{
+		Version:  3,
+		Value_:   "no",
+		Type_:    "content",
+		Scope_:   "done",
+		Origin_:  "here",
+		SpaceID_: "666",
+		CIDR_:    "no/24",
+	}
+
+	bytes, err := yaml.Marshal(initial)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var source map[string]interface{}
+	err = yaml.Unmarshal(bytes, &source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	addresss, err := importAddress(source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(addresss, jc.DeepEquals, initial)
+}

--- a/application_test.go
+++ b/application_test.go
@@ -95,8 +95,8 @@ func minimalApplicationMapCAAS() map[interface{}]interface{} {
 		"version":     1,
 		"provider-id": "some-provider",
 		"addresses": []interface{}{
-			map[interface{}]interface{}{"version": 2, "value": "10.0.0.1", "type": "special"},
-			map[interface{}]interface{}{"version": 2, "value": "10.0.0.2", "type": "other"},
+			map[interface{}]interface{}{"version": 3, "value": "10.0.0.1", "type": "special"},
+			map[interface{}]interface{}{"version": 3, "value": "10.0.0.2", "type": "other"},
 		},
 	}
 	result["units"] = map[interface{}]interface{}{

--- a/cloudcontainer_test.go
+++ b/cloudcontainer_test.go
@@ -41,7 +41,7 @@ func (s *CloudContainerSerializationSuite) TestAllArgs(c *gc.C) {
 	container := newCloudContainer(&args)
 
 	c.Check(container.ProviderId(), gc.Equals, args.ProviderId)
-	c.Check(container.Address(), jc.DeepEquals, &address{Version: 2, Value_: "10.0.0.1", Type_: "special"})
+	c.Check(container.Address(), jc.DeepEquals, &address{Version: 3, Value_: "10.0.0.1", Type_: "special"})
 
 	c.Check(container.Ports(), jc.DeepEquals, args.Ports)
 }

--- a/cloudservice_test.go
+++ b/cloudservice_test.go
@@ -43,8 +43,8 @@ func (s *CloudServiceSerializationSuite) TestAllArgs(c *gc.C) {
 
 	c.Check(container.ProviderId(), gc.Equals, args.ProviderId)
 	c.Check(container.Addresses(), jc.DeepEquals, []Address{
-		&address{Version: 2, Value_: "10.0.0.1", Type_: "special"},
-		&address{Version: 2, Value_: "10.0.0.2", Type_: "other"},
+		&address{Version: 3, Value_: "10.0.0.1", Type_: "special"},
+		&address{Version: 3, Value_: "10.0.0.2", Type_: "other"},
 	})
 }
 

--- a/unit_test.go
+++ b/unit_test.go
@@ -66,7 +66,7 @@ func minimalUnitMapCAAS() map[interface{}]interface{} {
 	result["cloud-container"] = map[interface{}]interface{}{
 		"version":     1,
 		"provider-id": "some-provider",
-		"address":     map[interface{}]interface{}{"version": 2, "value": "10.0.0.1", "type": "special"},
+		"address":     map[interface{}]interface{}{"version": 3, "value": "10.0.0.1", "type": "special"},
 		"ports":       []interface{}{"80", "443"},
 	}
 	return result


### PR DESCRIPTION
This commit adds a new CIDR field to the Address structure and updates relevant functions and tests to handle this new field. The version of the Address structure is incremented to 3 to reflect this change.

~CIDR is required as part of address description for PR https://github.com/juju/juju/pull/18297,linked to Launchpad bug: https://bugs.launchpad.net/juju/+bug/2073986~ (Edited: Not required anymore, but this PR can be useful for consistency)