### PR TITLE
feat: make status history optional

### DIFF
--- a/application.go
+++ b/application.go
@@ -756,7 +756,7 @@ func applicationV1Fields() (schema.Fields, schema.Defaults) {
 	}
 	addAnnotationSchema(fields, defaults)
 	addConstraintsSchema(fields, defaults)
-	addStatusHistorySchema(fields)
+	addStatusHistorySchema(fields, defaults)
 	return fields, defaults
 }
 

--- a/application_test.go
+++ b/application_test.go
@@ -768,3 +768,58 @@ func (s *ApplicationSerializationSuite) TestApplicationSeriesToPlatform(c *gc.C)
 
 	c.Assert(app[0].CharmOrigin().Platform(), gc.Equals, "unknown/ubuntu/20.04")
 }
+
+func (s *ApplicationSerializationSuite) TestApplicationWithoutStatusHistory(c *gc.C) {
+	appInput := map[string]interface{}{
+		"version": 8,
+		"applications": []map[string]interface{}{{
+			"version":           8,
+			"name":              "ubuntu",
+			"type":              IAAS,
+			"charm-url":         "cs:trusty/ubuntu",
+			"cs-channel":        "stable",
+			"charm-mod-version": 1,
+			"status":            minimalStatusMap(),
+			"settings": map[interface{}]interface{}{
+				"key": "value",
+			},
+			"leader":              "ubuntu/0",
+			"leadership-settings": map[interface{}]interface{}{},
+			"metrics-creds":       "c2Vrcml0", // base64 encoded
+			"resources": map[interface{}]interface{}{
+				"version": 1,
+				"resources": []interface{}{
+					minimalResourceMap(),
+				},
+			},
+			"units": map[interface{}]interface{}{
+				"version": 3,
+				"units": []interface{}{
+					minimalUnitMap(),
+				},
+			},
+			"series": "focal",
+			"charm-origin": map[interface{}]interface{}{
+				"version":  2,
+				"source":   "local",
+				"id":       "",
+				"hash":     "",
+				"revision": 0,
+				"channel":  "",
+				"platform": "",
+			},
+		}},
+	}
+
+	bytes, err := yaml.Marshal(appInput)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var source map[string]interface{}
+	err = yaml.Unmarshal(bytes, &source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	app, err := importApplications(source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(app[0].StatusHistory(), gc.HasLen, 0)
+}

--- a/cloudinstance.go
+++ b/cloudinstance.go
@@ -258,7 +258,7 @@ func cloudInstanceV1Fields() (schema.Fields, schema.Defaults) {
 func cloudInstanceV2Fields() (schema.Fields, schema.Defaults) {
 	fields, defaults := cloudInstanceV1Fields()
 	fields["status"] = schema.StringMap(schema.Any())
-	addStatusHistorySchema(fields)
+	addStatusHistorySchema(fields, defaults)
 	return fields, defaults
 }
 

--- a/filesystem.go
+++ b/filesystem.go
@@ -219,7 +219,7 @@ func importFilesystemV1(source map[string]interface{}) (*filesystem, error) {
 		"filesystem-id": "",
 		"attachments":   schema.Omit,
 	}
-	addStatusHistorySchema(fields)
+	addStatusHistorySchema(fields, defaults)
 	checker := schema.FieldMap(fields, defaults)
 
 	coerced, err := checker.Coerce(source, nil)

--- a/machine.go
+++ b/machine.go
@@ -669,7 +669,7 @@ func machineSchemaV1() (schema.Fields, schema.Defaults) {
 
 	addAnnotationSchema(fields, defaults)
 	addConstraintsSchema(fields, defaults)
-	addStatusHistorySchema(fields)
+	addStatusHistorySchema(fields, defaults)
 
 	return fields, defaults
 }

--- a/model.go
+++ b/model.go
@@ -1652,7 +1652,7 @@ func modelV2Fields() (schema.Fields, schema.Defaults) {
 			"info": schema.String(),
 		}, nil)
 	fields["status"] = schema.StringMap(schema.Any())
-	addStatusHistorySchema(fields)
+	addStatusHistorySchema(fields, defaults)
 	return fields, defaults
 }
 

--- a/model_test.go
+++ b/model_test.go
@@ -1683,6 +1683,23 @@ func (s *ModelSerializationSuite) TestAgentVersionPre11Import(c *gc.C) {
 	c.Check(model.AgentVersion(), gc.Equals, "3.3.3")
 }
 
+func (s *ModelSerializationSuite) TestModelWithoutStatusHistory(c *gc.C) {
+	initial := s.newModel(ModelArgs{
+		Config: map[string]any{
+			"agent-version": "3.3.3",
+		},
+	})
+	data := asStringMap(c, initial)
+	delete(data, "status-history")
+	bytes, err := yaml.Marshal(data)
+	c.Assert(err, jc.ErrorIsNil)
+
+	model, err := Deserialize(bytes)
+	c.Check(err, jc.ErrorIsNil)
+
+	c.Check(model.StatusHistory(), gc.HasLen, 0)
+}
+
 // modelV1example was taken from a Juju 2.1 model dump, which is version
 // 1, and among other things is missing model status, which version 2 makes
 // manditory.

--- a/status.go
+++ b/status.go
@@ -284,10 +284,15 @@ func (s *StatusHistory_) SetStatusHistory(args []StatusArgs) {
 	s.History = points
 }
 
-func addStatusHistorySchema(fields schema.Fields) {
+func addStatusHistorySchema(fields schema.Fields, defaults schema.Defaults) {
 	fields["status-history"] = schema.StringMap(schema.Any())
+	defaults["status-history"] = schema.Omit
 }
 
 func (s *StatusHistory_) importStatusHistory(valid map[string]interface{}) error {
-	return importStatusHistory(s, valid["status-history"].(map[string]interface{}))
+	history, ok := valid["status-history"]
+	if !ok {
+		return nil
+	}
+	return importStatusHistory(s, history.(map[string]interface{}))
 }

--- a/volume.go
+++ b/volume.go
@@ -300,7 +300,7 @@ func importVolumeV1(source map[string]interface{}) (*volume, error) {
 		"attachments":     schema.Omit,
 		"attachmentplans": schema.Omit,
 	}
-	addStatusHistorySchema(fields)
+	addStatusHistorySchema(fields, defaults)
 	checker := schema.FieldMap(fields, defaults)
 
 	coerced, err := checker.Coerce(source, nil)


### PR DESCRIPTION
This makes status history optional for the description package. As we're no longer storing the status history in dqlite, we don't need to pass it in the description package. We still allow it to be sent, we just ignore it if it is missing.