### PR TITLE
refactor: remove model status from description

### DIFF
--- a/status.go
+++ b/status.go
@@ -289,6 +289,17 @@ func addStatusHistorySchema(fields schema.Fields, defaults schema.Defaults) {
 	defaults["status-history"] = schema.Omit
 }
 
+// removeStatusHistorySchema performs the inverse actions of
+// [addStatusHistorySchema] removing any previously set status history schema
+// fields or defaults.
+//
+// If no status history schema or defaults has been set then this func will
+// result in a no-op.
+func removeStatusHistorySchema(fields schema.Fields, defaults schema.Defaults) {
+	delete(fields, "status-history")
+	delete(defaults, "status-history")
+}
+
 func (s *StatusHistory_) importStatusHistory(valid map[string]interface{}) error {
 	history, ok := valid["status-history"]
 	if !ok {


### PR DESCRIPTION
This commit removes model status and status history from the top level model in the description package. Status for other entities within a model such as machine has been left un-touched.

With the move to Juju 4.0 a model's status is now computed for every request as it is considered display information only. This means because we can now compute the value we know longer need to store and forward this when migrating and exporting models from Juju 4.0 onwards.

As part of this removal and change I have also introduced a new version 13 of description to represent the version for which this information was removed.

All unit tests pass and have been updated to account for the changes made in this PR.