### PR TITLE
feat: expose application config setters

### DIFF
--- a/application.go
+++ b/application.go
@@ -44,7 +44,10 @@ type Application interface {
 	EndpointBindings() map[string]string
 
 	CharmConfig() map[string]interface{}
+	SetCharmConfig(map[string]interface{})
+
 	ApplicationConfig() map[string]interface{}
+	SetApplicationConfig(map[string]interface{})
 
 	Leader() string
 	LeadershipSettings() map[string]interface{}
@@ -345,9 +348,19 @@ func (a *application) ApplicationConfig() map[string]interface{} {
 	return a.ApplicationConfig_
 }
 
+// SetApplicationConfig implements Application.
+func (a *application) SetApplicationConfig(args map[string]interface{}) {
+	a.ApplicationConfig_ = args
+}
+
 // CharmConfig implements Application.
 func (a *application) CharmConfig() map[string]interface{} {
 	return a.CharmConfig_
+}
+
+// SetCharmConfig implements Application.
+func (a *application) SetCharmConfig(args map[string]interface{}) {
+	a.CharmConfig_ = args
 }
 
 // Leader implements Application.

--- a/application_test.go
+++ b/application_test.go
@@ -281,6 +281,44 @@ func (s *ApplicationSerializationSuite) TestNewApplication(c *gc.C) {
 	c.Assert(application.MetricsCredentials(), jc.DeepEquals, []byte("sekrit"))
 }
 
+func (s *ApplicationSerializationSuite) TestSetApplicationConfig(c *gc.C) {
+	args := ApplicationArgs{
+		Tag: names.NewApplicationTag("magic"),
+		ApplicationConfig: map[string]interface{}{
+			"config key": "config value",
+		},
+	}
+	application := newApplication(args)
+
+	// This will overwrite the existing application config in the application
+	// with the new one.
+	application.SetApplicationConfig(map[string]interface{}{
+		"new key": "new value",
+	})
+	c.Assert(application.ApplicationConfig(), jc.DeepEquals, map[string]interface{}{
+		"new key": "new value",
+	})
+}
+
+func (s *ApplicationSerializationSuite) TestSetCharmConfig(c *gc.C) {
+	args := ApplicationArgs{
+		Tag: names.NewApplicationTag("magic"),
+		CharmConfig: map[string]interface{}{
+			"key": "value",
+		},
+	}
+	application := newApplication(args)
+
+	// This will overwrite the existing charm config in the application
+	// with the new one.
+	application.SetCharmConfig(map[string]interface{}{
+		"new key": "new value",
+	})
+	c.Assert(application.CharmConfig(), jc.DeepEquals, map[string]interface{}{
+		"new key": "new value",
+	})
+}
+
 func (s *ApplicationSerializationSuite) TestMinimalApplicationValid(c *gc.C) {
 	application := minimalApplication()
 	c.Assert(application.Validate(), jc.ErrorIsNil)


### PR DESCRIPTION
The creation of a description.Application is not done in one location instead it's built up over time. This allows the setting of the application config at a later point.