### PR TITLE
feat: resource description v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode/
+.idea/

--- a/application.go
+++ b/application.go
@@ -520,7 +520,7 @@ func (a *application) AddResource(args ResourceArgs) Resource {
 
 func (a *application) setResources(resourceList []*resource) {
 	a.Resources_ = resources{
-		Version:    1,
+		Version:    2,
 		Resources_: resourceList,
 	}
 }

--- a/application_test.go
+++ b/application_test.go
@@ -53,7 +53,7 @@ func minimalApplicationMap() map[interface{}]interface{} {
 		},
 		"metrics-creds": "c2Vrcml0", // base64 encoded
 		"resources": map[interface{}]interface{}{
-			"version": 1,
+			"version": 2,
 			"resources": []interface{}{
 				minimalResourceMap(),
 			},
@@ -770,7 +770,7 @@ func (s *ApplicationSerializationSuite) TestApplicationSeriesToPlatform(c *gc.C)
 			"leadership-settings": map[interface{}]interface{}{},
 			"metrics-creds":       "c2Vrcml0", // base64 encoded
 			"resources": map[interface{}]interface{}{
-				"version": 1,
+				"version": 2,
 				"resources": []interface{}{
 					minimalResourceMap(),
 				},
@@ -825,7 +825,7 @@ func (s *ApplicationSerializationSuite) TestApplicationWithoutStatusHistory(c *g
 			"leadership-settings": map[interface{}]interface{}{},
 			"metrics-creds":       "c2Vrcml0", // base64 encoded
 			"resources": map[interface{}]interface{}{
-				"version": 1,
+				"version": 2,
 				"resources": []interface{}{
 					minimalResourceMap(),
 				},

--- a/unit.go
+++ b/unit.go
@@ -353,7 +353,7 @@ func (u *unit) Resources() []UnitResource {
 
 func (u *unit) setResources(resourceList []*unitResource) {
 	u.Resources_ = unitResources{
-		Version:    1,
+		Version:    2,
 		Resources_: resourceList,
 	}
 }

--- a/unit_test.go
+++ b/unit_test.go
@@ -40,7 +40,7 @@ func minimalUnitMap() map[interface{}]interface{} {
 		"password-hash":            "secure-hash",
 		"tools":                    minimalAgentToolsMap(),
 		"resources": map[interface{}]interface{}{
-			"version":   1,
+			"version":   2,
 			"resources": []interface{}{},
 		},
 		"payloads": map[interface{}]interface{}{


### PR DESCRIPTION
This changes adds V2 of the resource description.

Previously, resources had optional information about the "path" and
"description" of the resource. This information is contained in the
charm resource metadata and not needed in resource migration.

The FingerprintHex field name is changed to SHA384 and the Username to
RetrievedBy. This more accuratly reflects the contents of the field

This change also adds kubernetes-application-revisions. These are added
to migrate information about the current resource revision used by a
kubernetes application, as this may differe from the application
revision.

The size, fingerprint and retrieved-by of the resource are not migrated
to the new database using the description package, however, they are
fetched from the model description by the migrationmaster facade to send
to the migrationmaster worker which does the upload of the binary
resource blob via HTTP. It is in these HTTP headers that this
information is transmitted to the new controller. For this reason, it
stays in the description package.

Bundles also make use of this package, however they only touch the
Origin and Revision fields of the resource, which are unaffected by
these changes.

Jira ticket: [JUJU-7582](https://warthogs.atlassian.net/browse/JUJU-7582)

[JUJU-7582]: https://warthogs.atlassian.net/browse/JUJU-7582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ