### PR TITLE
feat: add virtual host keys

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -357,3 +357,9 @@ type CharmConfig interface {
 	Default() interface{}
 	Description() string
 }
+
+// CharmConfig represents a virtual host key of a unit/machine.
+type VirtualHostKey interface {
+	ID() string
+	HostKey() []byte
+}

--- a/model.go
+++ b/model.go
@@ -142,6 +142,9 @@ type Model interface {
 	PasswordHash() string
 
 	AddBlockDevice(string, BlockDeviceArgs) error
+
+	VirtualHostKeys() []VirtualHostKey
+	AddVirtualHostKey(args VirtualHostKeyArgs) VirtualHostKey
 }
 
 // ModelArgs represent the bare minimum information that is needed
@@ -165,7 +168,7 @@ type ModelArgs struct {
 // NewModel returns a Model based on the args specified.
 func NewModel(args ModelArgs) Model {
 	m := &model{
-		Version:             11,
+		Version:             12,
 		AgentVersion_:       args.AgentVersion,
 		Type_:               args.Type,
 		Owner_:              args.Owner.Id(),
@@ -204,6 +207,7 @@ func NewModel(args ModelArgs) Model {
 	m.setFirewallRules(nil)
 	m.setOfferConnections(nil)
 	m.setExternalControllers(nil)
+	m.setVirtualHostKeys(nil)
 
 	return m
 }
@@ -322,6 +326,8 @@ type model struct {
 	MeterStatus_ meterStatus `yaml:"meter-status"`
 
 	PasswordHash_ string `yaml:"password-hash,omitempty"`
+
+	VirtualHostKeys_ virtualHostKeys `yaml:"virtual-host-keys"`
 }
 
 // AgentVersion returns the current agent version in use the by the model.
@@ -459,6 +465,29 @@ func (m *model) AddBlockDevice(machineId string, bdArgs BlockDeviceArgs) error {
 		return nil
 	}
 	return fmt.Errorf("machine %q %w", machineId, errors.NotFound)
+}
+
+// VirtualHostKey implements Model.
+func (m *model) VirtualHostKeys() []VirtualHostKey {
+	var result []VirtualHostKey
+	for _, hostKey := range m.VirtualHostKeys_.VirtualHostKeys {
+		result = append(result, hostKey)
+	}
+	return result
+}
+
+// AddVirtualHostKey implements Model.
+func (m *model) AddVirtualHostKey(args VirtualHostKeyArgs) VirtualHostKey {
+	hk := newVirtualHostKey(args)
+	m.VirtualHostKeys_.VirtualHostKeys = append(m.VirtualHostKeys_.VirtualHostKeys, hk)
+	return hk
+}
+
+func (m *model) setVirtualHostKeys(virtualHostKeyList []*virtualHostKey) {
+	m.VirtualHostKeys_ = virtualHostKeys{
+		Version:         1,
+		VirtualHostKeys: virtualHostKeyList,
+	}
 }
 
 // Applications implements Model.
@@ -1171,6 +1200,11 @@ func (m *model) Validate() error {
 		return errors.Trace(err)
 	}
 
+	err = m.validateVirtualHostKeys(validationCtx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	return nil
 }
 
@@ -1365,6 +1399,16 @@ func (m *model) validateSecrets(validationCtx *validationContext) error {
 	return nil
 }
 
+// validateVirtualHostKeys validates any virtual host keys
+func (m *model) validateVirtualHostKeys(_ *validationContext) error {
+	for i, hostKey := range m.VirtualHostKeys_.VirtualHostKeys {
+		if err := hostKey.Validate(); err != nil {
+			return errors.Annotatef(err, "virtual host key[%d]", i)
+		}
+	}
+	return nil
+}
+
 func (m *model) machineMaps() (map[string]Machine, map[string]map[string]LinkLayerDevice) {
 	machineIDs := make(map[string]Machine)
 	for _, machine := range m.Machines_.Machines_ {
@@ -1547,6 +1591,7 @@ var modelDeserializationFuncs = map[int]modelDeserializationFunc{
 	9:  newModelImporter(9, schema.FieldMap(modelV9Fields())),
 	10: newModelImporter(10, schema.FieldMap(modelV10Fields())),
 	11: newModelImporter(11, schema.FieldMap(modelV11Fields())),
+	12: newModelImporter(12, schema.FieldMap(modelV12Fields())),
 }
 
 func modelV1Fields() (schema.Fields, schema.Defaults) {
@@ -1666,11 +1711,17 @@ func modelV11Fields() (schema.Fields, schema.Defaults) {
 	return fields, defaults
 }
 
+func modelV12Fields() (schema.Fields, schema.Defaults) {
+	fields, defaults := modelV11Fields()
+	fields["virtual-host-keys"] = schema.StringMap(schema.Any())
+	return fields, defaults
+}
+
 func newModelFromValid(valid map[string]interface{}, importVersion int) (*model, error) {
 	// We're always making a version 8 model, no matter what we got on
 	// the way in.
 	result := &model{
-		Version:        11,
+		Version:        12,
 		Type_:          IAAS,
 		Owner_:         valid["owner"].(string),
 		Config_:        valid["config"].(map[string]interface{}),
@@ -1942,6 +1993,15 @@ func newModelFromValid(valid map[string]interface{}, importVersion int) (*model,
 		result.AgentVersion_ = valid["agent-version"].(string)
 	} else if result.Config_ != nil && result.Config_["agent-version"] != nil {
 		result.AgentVersion_ = result.Config_["agent-version"].(string)
+	}
+
+	if importVersion >= 12 {
+		virtualHostKeysMap := valid["virtual-host-keys"].(map[string]interface{})
+		virtualHostKeys, err := importVirtualHostKeys(virtualHostKeysMap)
+		if err != nil {
+			return nil, errors.Annotate(err, "virtual host keys")
+		}
+		result.setVirtualHostKeys(virtualHostKeys)
 	}
 
 	return result, nil

--- a/virtualhostkeys.go
+++ b/virtualhostkeys.go
@@ -1,0 +1,125 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package description
+
+import (
+	"encoding/base64"
+
+	"github.com/juju/errors"
+	"github.com/juju/schema"
+)
+
+type virtualHostKeys struct {
+	Version         int               `yaml:"version"`
+	VirtualHostKeys []*virtualHostKey `yaml:"virtual-host-keys"`
+}
+
+type virtualHostKey struct {
+	ID_      string `yaml:"id"`
+	HostKey_ string `yaml:"host-key"`
+}
+
+// ID implements VirtualHostKey
+func (f *virtualHostKey) ID() string {
+	return f.ID_
+}
+
+// HostKey implements VirtualHostKey
+func (f *virtualHostKey) HostKey() []byte {
+	// Here we are explicitly throwing away any decode error. We encode
+	// a byte array, so we know that the stored host key can be decoded.
+	hostKey, _ := base64.StdEncoding.DecodeString(f.HostKey_)
+	return hostKey
+}
+
+// Validate implements VirtualHostKey.
+func (f *virtualHostKey) Validate() error {
+	if f.ID_ == "" {
+		return errors.NotValidf("empty id")
+	}
+	if len(f.HostKey_) == 0 {
+		return errors.NotValidf("zero length key")
+	}
+	return nil
+}
+
+// VirtualHostKeyArgs is an argument struct used to add a virtual host key.
+type VirtualHostKeyArgs struct {
+	ID      string
+	HostKey []byte
+}
+
+func newVirtualHostKey(args VirtualHostKeyArgs) *virtualHostKey {
+	hostKey := base64.StdEncoding.EncodeToString(args.HostKey)
+	f := &virtualHostKey{
+		ID_:      args.ID,
+		HostKey_: hostKey,
+	}
+	return f
+}
+
+func importVirtualHostKeys(source map[string]interface{}) ([]*virtualHostKey, error) {
+	checker := versionedChecker("virtual-host-keys")
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "virtual host keys version schema check failed")
+	}
+	valid := coerced.(map[string]interface{})
+
+	version := int(valid["version"].(int64))
+	sourceList := valid["virtual-host-keys"].([]interface{})
+	return importVirtualHostKeyList(sourceList, version)
+}
+
+func importVirtualHostKeyList(sourceList []interface{}, version int) ([]*virtualHostKey, error) {
+	getFields, ok := virtualHostKeyFieldsFuncs[version]
+	if !ok {
+		return nil, errors.NotValidf("version %d", version)
+	}
+
+	result := make([]*virtualHostKey, 0, len(sourceList))
+	for i, value := range sourceList {
+		source, ok := value.(map[string]interface{})
+		if !ok {
+			return nil, errors.Errorf("unexpected value for virtual host keys %d, %T", i, value)
+		}
+		virtualHostKey, err := importVirtualHostKey(source, version, getFields)
+		if err != nil {
+			return nil, errors.Annotatef(err, "virtual host keys %d", i)
+		}
+		result = append(result, virtualHostKey)
+	}
+	return result, nil
+}
+
+var virtualHostKeyFieldsFuncs = map[int]fieldsFunc{
+	1: virtualHostKeyV1Fields,
+}
+
+func virtualHostKeyV1Fields() (schema.Fields, schema.Defaults) {
+	fields := schema.Fields{
+		"id":       schema.String(),
+		"host-key": schema.String(),
+	}
+	return fields, schema.Defaults{}
+}
+
+func importVirtualHostKey(source map[string]interface{}, importVersion int, fieldFunc func() (schema.Fields, schema.Defaults)) (*virtualHostKey, error) {
+	fields, defaults := fieldFunc()
+	checker := schema.FieldMap(fields, defaults)
+
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "virtual host keys v%d schema check failed", importVersion)
+	}
+	valid := coerced.(map[string]interface{})
+	// From here we know that the map returned from the schema coercion
+	// contains fields of the right type.
+
+	consumer := &virtualHostKey{
+		ID_:      valid["id"].(string),
+		HostKey_: valid["host-key"].(string),
+	}
+	return consumer, nil
+}

--- a/virtualhostkeys_test.go
+++ b/virtualhostkeys_test.go
@@ -1,0 +1,94 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package description
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
+)
+
+type VirtualHostKeysSerializationSuite struct {
+	SliceSerializationSuite
+}
+
+var _ = gc.Suite(&VirtualHostKeysSerializationSuite{})
+
+func (s *VirtualHostKeysSerializationSuite) SetUpTest(c *gc.C) {
+	s.SliceSerializationSuite.SetUpTest(c)
+	s.importName = "virtual host keys"
+	s.sliceName = "virtual-host-keys"
+	s.importFunc = func(m map[string]interface{}) (interface{}, error) {
+		return importVirtualHostKeys(m)
+	}
+	s.testFields = func(m map[string]interface{}) {
+		m["virtual-host-keys"] = []interface{}{}
+	}
+}
+
+func testVirtualHostKeyArgs() VirtualHostKeyArgs {
+	return VirtualHostKeyArgs{
+		ID:      "test-id",
+		HostKey: []byte("foo"),
+	}
+}
+
+func (s *VirtualHostKeysSerializationSuite) TestNewVirtualHostKey(c *gc.C) {
+	args := testVirtualHostKeyArgs()
+	virtualHostKey := newVirtualHostKey(args)
+
+	c.Check(virtualHostKey.ID(), gc.Equals, args.ID)
+	c.Check(virtualHostKey.HostKey(), gc.DeepEquals, []byte("foo"))
+}
+
+func (s *VirtualHostKeysSerializationSuite) TestVirtualHostKeyValid(c *gc.C) {
+	args := testVirtualHostKeyArgs()
+	virtualHostKey := newVirtualHostKey(args)
+	c.Assert(virtualHostKey.Validate(), jc.ErrorIsNil)
+}
+
+func (s *VirtualHostKeysSerializationSuite) TestValidation(c *gc.C) {
+	v := newVirtualHostKey(VirtualHostKeyArgs{ID: "", HostKey: []byte("foo")})
+	err := v.Validate()
+	c.Assert(err, gc.ErrorMatches, `empty id not valid`)
+
+	v = newVirtualHostKey(VirtualHostKeyArgs{ID: "test-id", HostKey: []byte{}})
+	err = v.Validate()
+	c.Assert(err, gc.ErrorMatches, `zero length key not valid`)
+}
+
+func (s *VirtualHostKeysSerializationSuite) TestVirtualHostKeyMatches(c *gc.C) {
+	args := testVirtualHostKeyArgs()
+
+	virtualHostKey := newVirtualHostKey(args)
+	out, err := yaml.Marshal(virtualHostKey)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(out), jc.YAMLEquals, virtualHostKey)
+}
+
+func (s *VirtualHostKeysSerializationSuite) exportImport(c *gc.C, virtualHostKey_ *virtualHostKey, version int) *virtualHostKey {
+	initial := virtualHostKeys{
+		Version:         version,
+		VirtualHostKeys: []*virtualHostKey{virtualHostKey_},
+	}
+
+	bytes, err := yaml.Marshal(initial)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var source map[string]interface{}
+	err = yaml.Unmarshal(bytes, &source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	virtualHostKeys, err := importVirtualHostKeys(source)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(virtualHostKeys, gc.HasLen, 1)
+	return virtualHostKeys[0]
+}
+
+func (s *VirtualHostKeysSerializationSuite) TestParsingSerializedData(c *gc.C) {
+	args := testVirtualHostKeyArgs()
+	original := newVirtualHostKey(args)
+	virtualHostKey := s.exportImport(c, original, 1)
+	c.Assert(virtualHostKey, jc.DeepEquals, original)
+}


### PR DESCRIPTION
# Description

This PR adds support for virtual host keys. A new collection in Juju 3.6 that will hold host keys, used as part of the SSH-proxy feature. 

Host keys hold byte sequences that cannot be directly serialised so I have opted to perform base64 encoding when serialising/de-serialising the data.

The data structure for the new host key collection is very simple, containing only `id` and `host-key` fields.