### PR TITLE
chore: bump to v9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROJECT := github.com/juju/description/v8
+PROJECT := github.com/juju/description/v9
 
 .PHONY: check-licence check-go check
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/juju/description/v8
+module github.com/juju/description/v9
 
 go 1.21
 

--- a/package_test.go
+++ b/package_test.go
@@ -25,7 +25,7 @@ var _ = gc.Suite(&ImportTest{})
 
 func (*ImportTest) TestImports(c *gc.C) {
 	imps, err := jtesting.FindImports(
-		"github.com/juju/description/v8",
+		"github.com/juju/description/v9",
 		"github.com/juju/juju/")
 	c.Assert(err, jc.ErrorIsNil)
 	// This package brings in nothing else from juju/juju


### PR DESCRIPTION
This PR bumps `main` to `v9` as a follow-up to https://github.com/juju/description/pull/165