### PR TITLE
revert: downgrade Go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/juju/description/v8
 
-go 1.24
+go 1.23
 
 require (
 	github.com/juju/collections v1.0.0


### PR DESCRIPTION
This PR is a partial revert of https://github.com/juju/description/pull/167 where the Go toolchain was updated to v1.24. This would force juju/juju to also upgrade to v1.24 which is normally done after the first point release i.e. Go 1.24.1.
Reverting the toolchain down to Go 1.23 to match the tip of Juju 3.6.