### PR TITLE
chore: merge v8 to main

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/juju/description/v9
 
-go 1.21
+go 1.23
 
 require (
 	github.com/juju/collections v1.0.0

--- a/interfaces.go
+++ b/interfaces.go
@@ -373,3 +373,9 @@ type CharmConfig interface {
 	Default() interface{}
 	Description() string
 }
+
+// VirtualHostKey represents a virtual host key of a unit/machine.
+type VirtualHostKey interface {
+	ID() string
+	HostKey() []byte
+}

--- a/virtualhostkeys.go
+++ b/virtualhostkeys.go
@@ -1,0 +1,133 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package description
+
+import (
+	"encoding/base64"
+
+	"github.com/juju/errors"
+	"github.com/juju/schema"
+)
+
+type virtualHostKeys struct {
+	Version         int               `yaml:"version"`
+	VirtualHostKeys []*virtualHostKey `yaml:"virtual-host-keys"`
+}
+
+type virtualHostKey struct {
+	ID_      string `yaml:"id"`
+	HostKey_ string `yaml:"host-key"`
+}
+
+// ID implements VirtualHostKey
+func (f *virtualHostKey) ID() string {
+	return f.ID_
+}
+
+// HostKey implements VirtualHostKey
+func (f *virtualHostKey) HostKey() []byte {
+	// Here we are explicitly throwing away any decode error. We encode
+	// a byte array, so we know that the stored host key can be decoded.
+	// We also verify during import that the content can be decoded.
+	hostKey, _ := base64.StdEncoding.DecodeString(f.HostKey_)
+	return hostKey
+}
+
+// Validate implements VirtualHostKey.
+func (f *virtualHostKey) Validate() error {
+	if f.ID_ == "" {
+		return errors.NotValidf("empty id")
+	}
+	if f.HostKey_ == "" {
+		return errors.NotValidf("zero length key")
+	}
+	return nil
+}
+
+// VirtualHostKeyArgs is an argument struct used to add a virtual host key.
+type VirtualHostKeyArgs struct {
+	ID      string
+	HostKey []byte
+}
+
+func newVirtualHostKey(args VirtualHostKeyArgs) *virtualHostKey {
+	hostKey := base64.StdEncoding.EncodeToString(args.HostKey)
+	f := &virtualHostKey{
+		ID_:      args.ID,
+		HostKey_: hostKey,
+	}
+	return f
+}
+
+func importVirtualHostKeys(source map[string]interface{}) ([]*virtualHostKey, error) {
+	checker := versionedChecker("virtual-host-keys")
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "virtual host keys version schema check failed")
+	}
+	valid := coerced.(map[string]interface{})
+
+	version := int(valid["version"].(int64))
+	sourceList := valid["virtual-host-keys"].([]interface{})
+	return importVirtualHostKeyList(sourceList, version)
+}
+
+func importVirtualHostKeyList(sourceList []interface{}, version int) ([]*virtualHostKey, error) {
+	getFields, ok := virtualHostKeyFieldsFuncs[version]
+	if !ok {
+		return nil, errors.NotValidf("version %d", version)
+	}
+
+	result := make([]*virtualHostKey, 0, len(sourceList))
+	for i, value := range sourceList {
+		source, ok := value.(map[string]interface{})
+		if !ok {
+			return nil, errors.Errorf("unexpected value for virtual host keys %d, %T", i, value)
+		}
+		virtualHostKey, err := importVirtualHostKey(source, version, getFields)
+		if err != nil {
+			return nil, errors.Annotatef(err, "virtual host keys %d", i)
+		}
+		result = append(result, virtualHostKey)
+	}
+	return result, nil
+}
+
+var virtualHostKeyFieldsFuncs = map[int]fieldsFunc{
+	1: virtualHostKeyV1Fields,
+}
+
+func virtualHostKeyV1Fields() (schema.Fields, schema.Defaults) {
+	fields := schema.Fields{
+		"id":       schema.String(),
+		"host-key": schema.String(),
+	}
+	return fields, schema.Defaults{}
+}
+
+func importVirtualHostKey(source map[string]interface{}, importVersion int, fieldFunc func() (schema.Fields, schema.Defaults)) (*virtualHostKey, error) {
+	fields, defaults := fieldFunc()
+	checker := schema.FieldMap(fields, defaults)
+
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "virtual host keys v%d schema check failed", importVersion)
+	}
+	valid := coerced.(map[string]interface{})
+	// From here we know that the map returned from the schema coercion
+	// contains fields of the right type.
+
+	hostKey := valid["host-key"].(string)
+	// The model stores the virtual host key encoded, but we want to
+	// make sure that we are storing something that can be decoded.
+	if _, err := base64.StdEncoding.DecodeString(hostKey); err != nil {
+		return nil, errors.Annotate(err, "virtual host key not valid")
+	}
+
+	consumer := &virtualHostKey{
+		ID_:      valid["id"].(string),
+		HostKey_: hostKey,
+	}
+	return consumer, nil
+}

--- a/virtualhostkeys_test.go
+++ b/virtualhostkeys_test.go
@@ -1,0 +1,105 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package description
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
+)
+
+type VirtualHostKeysSerializationSuite struct {
+	SliceSerializationSuite
+}
+
+var _ = gc.Suite(&VirtualHostKeysSerializationSuite{})
+
+func (s *VirtualHostKeysSerializationSuite) SetUpTest(c *gc.C) {
+	s.SliceSerializationSuite.SetUpTest(c)
+	s.importName = "virtual host keys"
+	s.sliceName = "virtual-host-keys"
+	s.importFunc = func(m map[string]interface{}) (interface{}, error) {
+		return importVirtualHostKeys(m)
+	}
+	s.testFields = func(m map[string]interface{}) {
+		m["virtual-host-keys"] = []interface{}{}
+	}
+}
+
+func testVirtualHostKeyArgs() VirtualHostKeyArgs {
+	return VirtualHostKeyArgs{
+		ID:      "test-id",
+		HostKey: []byte("foo"),
+	}
+}
+
+func (s *VirtualHostKeysSerializationSuite) TestNewVirtualHostKey(c *gc.C) {
+	args := testVirtualHostKeyArgs()
+	virtualHostKey := newVirtualHostKey(args)
+
+	c.Check(virtualHostKey.ID(), gc.Equals, args.ID)
+	c.Check(virtualHostKey.HostKey(), gc.DeepEquals, []byte("foo"))
+}
+
+func (s *VirtualHostKeysSerializationSuite) TestVirtualHostKeyValid(c *gc.C) {
+	args := testVirtualHostKeyArgs()
+	virtualHostKey := newVirtualHostKey(args)
+	c.Assert(virtualHostKey.Validate(), jc.ErrorIsNil)
+}
+
+func (s *VirtualHostKeysSerializationSuite) TestValidation(c *gc.C) {
+	v := newVirtualHostKey(VirtualHostKeyArgs{ID: "", HostKey: []byte("foo")})
+	err := v.Validate()
+	c.Assert(err, gc.ErrorMatches, `empty id not valid`)
+
+	v = newVirtualHostKey(VirtualHostKeyArgs{ID: "test-id", HostKey: []byte{}})
+	err = v.Validate()
+	c.Assert(err, gc.ErrorMatches, `zero length key not valid`)
+}
+
+func (s *VirtualHostKeysSerializationSuite) TestVirtualHostKeyMatches(c *gc.C) {
+	args := testVirtualHostKeyArgs()
+
+	virtualHostKey := newVirtualHostKey(args)
+	out, err := yaml.Marshal(virtualHostKey)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(out), jc.YAMLEquals, virtualHostKey)
+}
+
+func (s *VirtualHostKeysSerializationSuite) exportImport(c *gc.C, virtualHostKey_ *virtualHostKey, version int, expectError string) *virtualHostKey {
+	initial := virtualHostKeys{
+		Version:         version,
+		VirtualHostKeys: []*virtualHostKey{virtualHostKey_},
+	}
+
+	bytes, err := yaml.Marshal(initial)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var source map[string]interface{}
+	err = yaml.Unmarshal(bytes, &source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	virtualHostKeys, err := importVirtualHostKeys(source)
+	if expectError != "" {
+		c.Assert(err, gc.ErrorMatches, expectError)
+		return nil
+	}
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(virtualHostKeys, gc.HasLen, 1)
+	return virtualHostKeys[0]
+}
+
+func (s *VirtualHostKeysSerializationSuite) TestParsingSerializedData(c *gc.C) {
+	args := testVirtualHostKeyArgs()
+	original := newVirtualHostKey(args)
+	virtualHostKey := s.exportImport(c, original, 1, "")
+	c.Assert(virtualHostKey, jc.DeepEquals, original)
+}
+
+func (s *VirtualHostKeysSerializationSuite) TestParsingInvalidHostKey(c *gc.C) {
+	args := testVirtualHostKeyArgs()
+	original := newVirtualHostKey(args)
+	original.HostKey_ = "invalid"
+	_ = s.exportImport(c, original, 1, ".*virtual host key not valid.*")
+}


### PR DESCRIPTION
This PR forward merges the new `v8` branch to `main`. The v8 branch introduced the new model field `virtual-host-keys` and bumped the model version from 11->12.

Since the `main` branch was already on version 13 (i.e. 2 versions ahead), I have slotted in version 12 from `v8` and pushed up the existing versions, so the existing v12->v13 and v13->v14.

This seems okay to me since Juju 4 is not yer released and should be using compatible model versioning with Juju 3.6. 