### PR TITLE
fix: fix an issue importing legacy storage

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -193,7 +193,7 @@ func newStorageFromValid(valid map[string]interface{}, version int) (*storage, e
 	if version <= 3 {
 		if owner, ok := valid["owner"].(string); ok {
 			unitOwner, _ := strings.CutPrefix(owner, "unit-")
-			result.UnitOwner_ = unitOwner
+			result.UnitOwner_ = strings.ReplaceAll(unitOwner, "-", "/")
 		}
 	}
 	if owner, ok := valid["unit-owner"].(string); ok {


### PR DESCRIPTION
The storage owner was not being converted from a tag to a unit name properly.
Updated a unit test to check the fix.