### PR TITLE
feat: add SetProvisioningState method to application

### DIFF
--- a/application.go
+++ b/application.go
@@ -86,6 +86,7 @@ type Application interface {
 	AddOpenedPortRange(OpenedPortRangeArgs)
 
 	ProvisioningState() ProvisioningState
+	SetProvisioningState(*ProvisioningStateArgs)
 }
 
 // ExposedEndpoint encapsulates the details about the CIDRs and/or spaces that
@@ -674,6 +675,11 @@ func (a *application) ProvisioningState() ProvisioningState {
 		return nil
 	}
 	return a.ProvisioningState_
+}
+
+// SetProvisioningState implements Application.
+func (a *application) SetProvisioningState(args *ProvisioningStateArgs) {
+	a.ProvisioningState_ = newProvisioningState(args)
 }
 
 func importApplications(source map[string]interface{}) ([]*application, error) {

--- a/application_test.go
+++ b/application_test.go
@@ -390,6 +390,21 @@ func (s *ApplicationSerializationSuite) TestAddOpenedPortRange(c *gc.C) {
 	c.Assert(application.OpenedPortRanges().ByUnit(), gc.HasLen, 2)
 }
 
+func (s *ApplicationSerializationSuite) TestSetProvisioningState(c *gc.C) {
+	app := minimalApplication()
+	c.Assert(app.ProvisioningState(), gc.IsNil)
+
+	app.SetProvisioningState(&ProvisioningStateArgs{
+		Scaling:     true,
+		ScaleTarget: 42,
+	})
+
+	application := s.exportImportLatest(c, app)
+	c.Assert(application.ProvisioningState(), gc.NotNil)
+	c.Assert(application.ProvisioningState().Scaling(), gc.Equals, true)
+	c.Assert(application.ProvisioningState().ScaleTarget(), gc.Equals, 42)
+}
+
 func (s *ApplicationSerializationSuite) exportImportVersion(c *gc.C, application_ *application, version int) *application {
 	initial := applications{
 		Version:       version,


### PR DESCRIPTION
This patch adds `SetProvisioningState()` to the application to allow for export of the application scale in the application domain in Juju 4.0.

# QA

```
$ go test .
```