### PR TITLE
feat: add missing set desired scale method in application

### DIFF
--- a/application.go
+++ b/application.go
@@ -34,6 +34,7 @@ type Application interface {
 	PasswordHash() string
 	PodSpec() string
 	DesiredScale() int
+	SetDesiredScale(int)
 	Placement() string
 	HasResources() bool
 	CloudService() CloudService
@@ -325,6 +326,11 @@ func (a *application) HasResources() bool {
 // DesiredScale implements Application.
 func (a *application) DesiredScale() int {
 	return a.DesiredScale_
+}
+
+// DesiredScale implements Application.
+func (a *application) SetDesiredScale(scale int) {
+	a.DesiredScale_ = scale
 }
 
 // MinUnits implements Application.

--- a/application_test.go
+++ b/application_test.go
@@ -670,6 +670,15 @@ func (s *ApplicationSerializationSuite) TestDesiredScale(c *gc.C) {
 	c.Assert(application.DesiredScale(), gc.Equals, 3)
 }
 
+func (s *ApplicationSerializationSuite) TestSetDesiredScale(c *gc.C) {
+	args := minimalApplicationArgs(CAAS)
+	initial := minimalApplication(args)
+
+	application := s.exportImportLatest(c, initial)
+	application.SetDesiredScale(42)
+	c.Check(application.DesiredScale(), gc.Equals, 42)
+}
+
 func (s *ApplicationSerializationSuite) TestProvisioningState(c *gc.C) {
 	args := minimalApplicationArgs(CAAS)
 	args.ProvisioningState = &ProvisioningStateArgs{


### PR DESCRIPTION
Method for setting the desired scale was missing. 

This patch adds `SetDesiredScale(int)` to the application.

# QA

```
$ go test .
```