### PR TITLE
refactor: expose set leader

### DIFF
--- a/application.go
+++ b/application.go
@@ -46,6 +46,7 @@ type Application interface {
 	SetApplicationConfig(map[string]interface{})
 
 	Leader() string
+	SetLeader(string)
 	LeadershipSettings() map[string]interface{}
 
 	MetricsCredentials() []byte
@@ -347,6 +348,11 @@ func (a *application) SetCharmConfig(args map[string]interface{}) {
 // Leader implements Application.
 func (a *application) Leader() string {
 	return a.Leader_
+}
+
+// SetLeader implements Application.
+func (a *application) SetLeader(leader string) {
+	a.Leader_ = leader
 }
 
 // LeadershipSettings implements Application.

--- a/application_test.go
+++ b/application_test.go
@@ -577,6 +577,19 @@ func (s *ApplicationSerializationSuite) TestLeaderValid(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `missing unit for leader "ubuntu/1" not valid`)
 }
 
+func (s *ApplicationSerializationSuite) TestSetLeader(c *gc.C) {
+	args := minimalApplicationArgs(IAAS)
+	application := newApplication(args)
+
+	leader := application.Leader()
+	c.Check(leader, gc.Equals, "ubuntu/0")
+
+	application.SetLeader("ubuntu/1")
+
+	leader = application.Leader()
+	c.Check(leader, gc.Equals, "ubuntu/1")
+}
+
 func (s *ApplicationSerializationSuite) TestResourcesAreValidated(c *gc.C) {
 	application := minimalApplication()
 	application.AddResource(ResourceArgs{Name: "foo"})


### PR DESCRIPTION
We need to be able to set the application leader outside of the construction args.