### PR TITLE
fix: allow dash in unit name as storage owner

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -193,7 +193,7 @@ func newStorageFromValid(valid map[string]interface{}, version int) (*storage, e
 	if version <= 3 {
 		if owner, ok := valid["owner"].(string); ok {
 			unitOwner, _ := strings.CutPrefix(owner, "unit-")
-			result.UnitOwner_ = strings.ReplaceAll(unitOwner, "-", "/")
+			result.UnitOwner_ = replaceLast(unitOwner, "-", "/")
 		}
 	}
 	if owner, ok := valid["unit-owner"].(string); ok {
@@ -251,4 +251,13 @@ func storageV1Fields() (schema.Fields, schema.Defaults) {
 		"name":        schema.String(),
 		"attachments": schema.List(schema.String()),
 	}, defaults
+}
+
+func replaceLast(x, y, z string) string {
+	i := strings.LastIndex(x, y)
+	if i == -1 {
+		return x // Substring not found
+	}
+	// Combine the part before the last occurrence, the replacement, and the part after
+	return x[:i] + z + x[i+len(y):]
 }


### PR DESCRIPTION
Previously all dashs in an owner name were replaced with a backslash as part of the converstion from a unit tag to a unit name. However, a dash is valid in a unit or application name. Instead, cut of the prefix `unit-` and only replace the last dash with a backslash.

Found during implementation of storage import for model migration. The owner unit had a name of `"dummy/storage/0`, which did not match any known unit nor application. In 3.6, the unit name was `dummy-storage/0`.