### PR TITLE
feat: add new hostname field

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -27,6 +27,8 @@ type Machine interface {
 	Nonce() string
 	PasswordHash() string
 	Placement() string
+	Hostname() string
+	SetHostname(string)
 	Base() string
 	ContainerType() string
 	Jobs() []string
@@ -69,6 +71,7 @@ type machine struct {
 	Nonce_        string         `yaml:"nonce"`
 	PasswordHash_ string         `yaml:"password-hash"`
 	Placement_    string         `yaml:"placement,omitempty"`
+	Hostname_     string         `yaml:"hostname,omitempty"`
 	Instance_     *cloudInstance `yaml:"instance,omitempty"`
 	// Series obsolete from v3. Retained for tests.
 	Series_        string `yaml:"series,omitempty"`
@@ -106,6 +109,7 @@ type MachineArgs struct {
 	Nonce         string
 	PasswordHash  string
 	Placement     string
+	Hostname      string
 	Series        string
 	Base          string
 	ContainerType string
@@ -126,6 +130,7 @@ func newMachine(args MachineArgs) *machine {
 		Nonce_:         args.Nonce,
 		PasswordHash_:  args.PasswordHash,
 		Placement_:     args.Placement,
+		Hostname_:      args.Hostname,
 		Series_:        args.Series,
 		Base_:          args.Base,
 		ContainerType_: args.ContainerType,
@@ -164,6 +169,16 @@ func (m *machine) PasswordHash() string {
 // Placement implements Machine.
 func (m *machine) Placement() string {
 	return m.Placement_
+}
+
+// Hostname implements Machine.
+func (m *machine) Hostname() string {
+	return m.Hostname_
+}
+
+// SetHostname implements Machine.
+func (m *machine) SetHostname(hostname string) {
+	m.Hostname_ = hostname
 }
 
 // Instance implements Machine.
@@ -440,6 +455,7 @@ var machineDeserializationFuncs = map[int]machineDeserializationFunc{
 	1: importMachineV1,
 	2: importMachineV2,
 	3: importMachineV3,
+	4: importMachineV4,
 }
 
 func importMachineV1(source map[string]interface{}) (*machine, error) {
@@ -455,6 +471,11 @@ func importMachineV2(source map[string]interface{}) (*machine, error) {
 func importMachineV3(source map[string]interface{}) (*machine, error) {
 	fields, defaults := machineSchemaV3()
 	return importMachine(fields, defaults, 3, source, importMachineV3)
+}
+
+func importMachineV4(source map[string]interface{}) (*machine, error) {
+	fields, defaults := machineSchemaV4()
+	return importMachine(fields, defaults, 4, source, importMachineV4)
 }
 
 func importMachine(
@@ -493,6 +514,9 @@ func importMachine(
 		result.Base_ = fmt.Sprintf("%s@%s", strings.ToLower(os.String()), vers)
 	} else {
 		result.Base_ = valid["base"].(string)
+	}
+	if hostname, ok := valid["hostname"]; ok {
+		result.Hostname_ = hostname.(string)
 	}
 
 	result.importAnnotations(valid)
@@ -689,6 +713,15 @@ func machineSchemaV3() (schema.Fields, schema.Defaults) {
 	fields["base"] = schema.String()
 	delete(fields, "series")
 	delete(defaults, "schema")
+
+	return fields, defaults
+}
+
+func machineSchemaV4() (schema.Fields, schema.Defaults) {
+	fields, defaults := machineSchemaV3()
+
+	fields["hostname"] = schema.String()
+	defaults["hostname"] = schema.Omit
 
 	return fields, defaults
 }

--- a/machine_test.go
+++ b/machine_test.go
@@ -151,6 +151,7 @@ func (s *MachineSerializationSuite) machineArgs(id string) MachineArgs {
 		Nonce:         "a nonce",
 		PasswordHash:  "some-hash",
 		Placement:     "placement",
+		Hostname:      "machine-42",
 		Base:          "ubuntu@22.04",
 		ContainerType: "magic",
 		Jobs:          []string{"this", "that"},
@@ -164,12 +165,19 @@ func (s *MachineSerializationSuite) TestNewMachine(c *gc.C) {
 	c.Assert(m.Nonce(), gc.Equals, "a nonce")
 	c.Assert(m.PasswordHash(), gc.Equals, "some-hash")
 	c.Assert(m.Placement(), gc.Equals, "placement")
+	c.Assert(m.Hostname(), gc.Equals, "machine-42")
 	c.Assert(m.Base(), gc.Equals, "ubuntu@22.04")
 	c.Assert(m.ContainerType(), gc.Equals, "magic")
 	c.Assert(m.Jobs(), jc.DeepEquals, []string{"this", "that"})
 	supportedContainers, ok := m.SupportedContainers()
 	c.Assert(ok, jc.IsFalse)
 	c.Assert(supportedContainers, gc.IsNil)
+}
+
+func (s *MachineSerializationSuite) TestSetHostname(c *gc.C) {
+	m := newMachine(s.machineArgs("42"))
+	m.SetHostname("updated-42")
+	c.Assert(m.Hostname(), gc.Equals, "updated-42")
 }
 
 func (s *MachineSerializationSuite) TestMinimalMachineValid(c *gc.C) {
@@ -260,7 +268,7 @@ func (s *MachineSerializationSuite) TestMinimalMatches(c *gc.C) {
 
 func (*MachineSerializationSuite) TestNestedParsing(c *gc.C) {
 	machines, err := importMachines(map[string]interface{}{
-		"version": 3,
+		"version": 4,
 		"machines": []interface{}{
 			minimalMachineMap("0"),
 			minimalMachineMap("1",
@@ -402,7 +410,7 @@ func (s *MachineSerializationSuite) TestConstraints(c *gc.C) {
 }
 
 func (s *MachineSerializationSuite) exportImport(c *gc.C, machine_ *machine) *machine {
-	return s.exportImportVersion(c, machine_, 3)
+	return s.exportImportVersion(c, machine_, 4)
 }
 
 func (s *MachineSerializationSuite) exportImportVersion(c *gc.C, machine_ *machine, version int) *machine {
@@ -545,6 +553,14 @@ func (s *MachineSerializationSuite) TestV1ParsingReturnsLatest(c *gc.C) {
 	mLatest.Base_ = "ubuntu@20.04"
 	mLatest.Series_ = ""
 	c.Assert(mResult, jc.DeepEquals, mLatest)
+}
+
+func (s *MachineSerializationSuite) TestV3ParsingDropsHostname(c *gc.C) {
+	mV3 := minimalMachine("0")
+	mV3.SetHostname("machine-0")
+
+	mResult := s.exportImportVersion(c, mV3, 3)
+	c.Assert(mResult.Hostname(), gc.Equals, "")
 }
 
 type AgentToolsSerializationSuite struct {

--- a/model.go
+++ b/model.go
@@ -470,7 +470,7 @@ func (m *model) AddMachine(args MachineArgs) Machine {
 
 func (m *model) setMachines(machineList []*machine) {
 	m.Machines_ = machines{
-		Version:   3,
+		Version:   4,
 		Machines_: machineList,
 	}
 }


### PR DESCRIPTION
Bumps machine version to v4 and include a hostname field.

The target branch v11 ([ref](https://github.com/juju/description/tree/v11)) was created off v10. Essentially v11 will be v10 + hostname changes.

Next steps:

- bump to `v11` ([ref](https://github.com/juju/description/blob/92fdff833003052829a025dc54feb29e739ad977/go.mod#L1))
- create v12 branch off current v11 ([ref](https://github.com/juju/description/blob/ea6d3105b20cd2037ff6795c323e16a229b0c83b/go.mod#L1)) and bump to v12 ([ref](https://github.com/juju/description/blob/ea6d3105b20cd2037ff6795c323e16a229b0c83b/go.mod#L1))
- merge forward this change to v12
- juju 3.6 imports v11 and juju 4.0 imports v12
- jimm imports v11

Card: https://warthogs.atlassian.net/browse/JUJU-7682