### PR TITLE
chore: bump branch version to v12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROJECT := github.com/juju/description/v11
+PROJECT := github.com/juju/description/v12
 
 .PHONY: check-licence check-go check
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/juju/description/v11
+module github.com/juju/description/v12
 
 go 1.24
 

--- a/package_test.go
+++ b/package_test.go
@@ -25,7 +25,7 @@ var _ = gc.Suite(&ImportTest{})
 
 func (*ImportTest) TestImports(c *gc.C) {
 	imps, err := jtesting.FindImports(
-		"github.com/juju/description/v11",
+		"github.com/juju/description/v12",
 		"github.com/juju/juju/")
 	c.Assert(err, jc.ErrorIsNil)
 	// This package brings in nothing else from juju/juju


### PR DESCRIPTION
Bumps main to v12. The hostname merge forward is done #198. This has to be merged and included in 4.0 ASAP before juju 4.0.6 release.