### PR TITLE
chore: bump version to v11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROJECT := github.com/juju/description/v10
+PROJECT := github.com/juju/description/v11
 
 .PHONY: check-licence check-go check
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/juju/description/v10
+module github.com/juju/description/v11
 
 go 1.23
 

--- a/package_test.go
+++ b/package_test.go
@@ -25,7 +25,7 @@ var _ = gc.Suite(&ImportTest{})
 
 func (*ImportTest) TestImports(c *gc.C) {
 	imps, err := jtesting.FindImports(
-		"github.com/juju/description/v10",
+		"github.com/juju/description/v11",
 		"github.com/juju/juju/")
 	c.Assert(err, jc.ErrorIsNil)
 	// This package brings in nothing else from juju/juju


### PR DESCRIPTION
Bumps version branch to v11. This branch already contains hostname field.